### PR TITLE
タイポなどを修正

### DIFF
--- a/stock_search/index.html
+++ b/stock_search/index.html
@@ -41,11 +41,11 @@
     <meta property="og:type" content="website" />
     <meta
       property="og:url"
-      content="https://yfinance-jp-screener-serach.vercel.app"
+      content="https://yfinance-jp-screener-search.vercel.app"
     />
     <meta
       property="og:image"
-      content="https://yfinance-jp-screener-serach.vercel.app/image.png"
+      content="https://yfinance-jp-screener-search.vercel.app/image.png"
     />
 
     <!-- ============================= -->
@@ -62,7 +62,7 @@
     />
     <meta
       name="twitter:image"
-      content="https://yfinance-jp-screener-serach.vercel.app//image.png"
+      content="https://yfinance-jp-screener-search.vercel.app/image.png"
     />
     <meta name="twitter:site" content="@testkun08080" />
 

--- a/stock_search/src/hooks/useFilters.ts
+++ b/stock_search/src/hooks/useFilters.ts
@@ -341,19 +341,19 @@ export const useFilters = (data: StockData[]) => {
       // PER(過去12ヶ月)フィルター（trailingPE、過去12ヶ月分）（データがnull/undefinedの場合は含める）
       if (
         filters.trailingPEMin !== null &&
-        stock.PER(過去12ヶ月) !== null &&
-        stock.PER(過去12ヶ月) !== undefined &&
-        typeof stock.PER(過去12ヶ月) === "number" &&
-        stock.PER(過去12ヶ月) < filters.trailingPEMin
+        stock["PER(過去12ヶ月)"] !== null &&
+        stock["PER(過去12ヶ月)"] !== undefined &&
+        typeof stock["PER(過去12ヶ月)"] === "number" &&
+        stock["PER(過去12ヶ月)"] < filters.trailingPEMin
       ) {
         return false;
       }
       if (
         filters.trailingPEMax !== null &&
-        stock.PER(過去12ヶ月) !== null &&
-        stock.PER(過去12ヶ月) !== undefined &&
-        typeof stock.PER(過去12ヶ月) === "number" &&
-        stock.PER(過去12ヶ月) > filters.trailingPEMax
+        stock["PER(過去12ヶ月)"] !== null &&
+        stock["PER(過去12ヶ月)"] !== undefined &&
+        typeof stock["PER(過去12ヶ月)"] === "number" &&
+        stock["PER(過去12ヶ月)"] > filters.trailingPEMax
       ) {
         return false;
       }

--- a/stock_search/src/types/stock.ts
+++ b/stock_search/src/types/stock.ts
@@ -1,36 +1,36 @@
 export interface StockData {
-  会社名?: string;
-  銘柄コード?: string;
-  コード?: string;
-  業種?: string;
-  優先市場?: string;
-  決算月?: string | null;
-  // 会計基準?: string | null;
-  都道府県?: string | null;
-  時価総額?: number | null;
-  PBR?: number | null;
-  売上高?: number | null;
-  営業利益?: number | null;
-  営業利益率?: number | null;
-  当期純利益?: number | null;
-  純利益率?: number | null;
-  ROE?: number | null;
-  自己資本比率?: number | null;
+  "会社名"?: string;
+  "銘柄コード"?: string;
+  "コード"?: string;
+  "業種"?: string;
+  "優先市場"?: string;
+  "決算月"?: string | null;
+  // "会計基準"?: string | null;
+  "都道府県"?: string | null;
+  "時価総額"?: number | null;
+  "PBR"?: number | null;
+  "売上高"?: number | null;
+  "営業利益"?: number | null;
+  "営業利益率"?: number | null;
+  "当期純利益"?: number | null;
+  "純利益率"?: number | null;
+  "ROE"?: number | null;
+  "自己資本比率"?: number | null;
   "PER(会予)"?: number | null;
-  // PER?: number | null;  // 情報的に不確かなためコメントアウト
-  PER(過去12ヶ月)?: number | null; // trailingPE（過去12ヶ月分）
-  配当方向性?: number | null; // payoutRatio（生データ、小数、例: 0.3 = 30%）
-  配当利回り?: number | null; // trailingAnnualDividendYield（生データ、小数、例: 0.03 = 3%）
+  // "PER"?: number | null;  // 情報的に不確かなためコメントアウト
+  "PER(過去12ヶ月)"?: number | null; // trailingPE（過去12ヶ月分）
+  "配当方向性"?: number | null; // payoutRatio（生データ、小数、例: 0.3 = 30%）
+  "配当利回り"?: number | null; // trailingAnnualDividendYield（生データ、小数、例: 0.03 = 3%）
   "EPS(過去12ヶ月)"?: number | null; // trailingEps（生データ）
   "EPS(予想)"?: number | null; // forwardEps（生データ）
-  負債?: number | null;
-  流動負債?: number | null;
-  流動資産?: number | null;
-  総負債?: number | null;
-  現金及び現金同等物?: number | null;
-  投資有価証券?: number | null;
+  "負債"?: number | null;
+  "流動負債"?: number | null;
+  "流動資産"?: number | null;
+  "総負債"?: number | null;
+  "現金及び現金同等物"?: number | null;
+  "投資有価証券"?: number | null;
   "ネットキャッシュ（流動資産-負債）"?: number | null;
-  ネットキャッシュ比率?: number | null;
+  "ネットキャッシュ比率"?: number | null;
   _source_file?: string;
   _row_index?: number;
   [key: string]: string | number | null | undefined; // Allow additional dynamic properties


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix property access syntax for Japanese property names in filters

- Standardize all interface properties with quoted string keys

- Correct URL typo in OGP and Twitter meta tags


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["useFilters.ts<br/>Property Access"] -->|"Bracket notation"| B["Fixed Runtime<br/>Access"]
  C["stock.ts<br/>Interface Props"] -->|"Quoted keys"| D["Consistent<br/>Type Definition"]
  E["index.html<br/>URLs"] -->|"serach→search"| F["Corrected<br/>Meta Tags"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useFilters.ts</strong><dd><code>Fix property access syntax for Japanese property names</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

stock_search/src/hooks/useFilters.ts

<ul><li>Changed property access from dot notation to bracket notation for <br><code>PER(過去12ヶ月)</code> property<br> <li> Ensures proper access to properties with special characters and <br>parentheses<br> <li> Fixes 8 instances of incorrect property access across min/max filter <br>conditions</ul>


</details>


  </td>
  <td><a href="https://github.com/testkun08080/yfinance-jp-screener/pull/3/files#diff-0b92f0238f8d1bd2ee7568b5d29383263c9791c6abc900bed69b14a531985cdd">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>stock.ts</strong><dd><code>Standardize interface properties with quoted string keys</code>&nbsp; </dd></summary>
<hr>

stock_search/src/types/stock.ts

<ul><li>Wrapped all Japanese property names in double quotes for consistency<br> <li> Standardizes interface definition to use quoted string keys throughout<br> <li> Maintains compatibility with bracket notation property access<br> <li> Affects 18 properties in the StockData interface</ul>


</details>


  </td>
  <td><a href="https://github.com/testkun08080/yfinance-jp-screener/pull/3/files#diff-1158893de879dd34964c78d4ce8bf29ef34e7238edcc79ee7bf8b5ba923023f9">+28/-28</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Correct URL typos in meta tags</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

stock_search/index.html

<ul><li>Fixed URL typo: <code>serach</code> → <code>search</code> in OGP og:url property<br> <li> Fixed URL typo: <code>serach</code> → <code>search</code> in OGP og:image property<br> <li> Fixed URL typo: <code>serach</code> → <code>search</code> in Twitter meta image tag<br> <li> Removed double slash in Twitter image URL path</ul>


</details>


  </td>
  <td><a href="https://github.com/testkun08080/yfinance-jp-screener/pull/3/files#diff-f2754c5550de55ee57dcd097fa9533f36616197a0f921f67ffd4eeb6de5fe2ae">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

