### PR TITLE
サイドバーを開閉可能に

### DIFF
--- a/stock_search/src/components/Sidebar.tsx
+++ b/stock_search/src/components/Sidebar.tsx
@@ -1,5 +1,6 @@
 import {
   MdClose,
+  MdChevronLeft,
   MdFolderOpen,
   MdExpandMore,
   MdFilterList,
@@ -40,6 +41,8 @@ interface SidebarProps {
   onClose?: () => void;
   /** モバイル用ドロワーとして表示する場合 true */
   isDrawer?: boolean;
+  /** デスクトップでサイドバーを折りたたむコールバック（指定時は折りたたみボタンを表示） */
+  onCollapse?: () => void;
 }
 
 function NumRange({
@@ -108,6 +111,7 @@ export const Sidebar = ({
   availablePrefectures,
   onClose,
   isDrawer = false,
+  onCollapse,
 }: SidebarProps) => {
   const handleDatasetDrop = (e: React.DragEvent) => {
     e.preventDefault();
@@ -154,17 +158,30 @@ export const Sidebar = ({
         isDrawer ? "shadow-xl" : ""
       }`}
     >
-      {/* モバイルドロワー用: 閉じるボタン */}
-      {onClose && (
-        <div className="flex items-center justify-end p-2 border-b border-[var(--border)] md:hidden">
-          <button
-            type="button"
-            className="p-2 rounded-lg hover:bg-slate-100 text-slate-600"
-            onClick={onClose}
-            aria-label="閉じる"
-          >
-            <MdClose />
-          </button>
+      {/* ヘッダー: モバイル閉じる / デスクトップ折りたたみ */}
+      {(onClose || onCollapse) && (
+        <div className="flex items-center justify-end gap-1 p-2 border-b border-[var(--border)]">
+          {onClose && (
+            <button
+              type="button"
+              className="p-2 rounded-lg hover:bg-slate-100 text-slate-600"
+              onClick={onClose}
+              aria-label="閉じる"
+            >
+              <MdClose />
+            </button>
+          )}
+          {onCollapse && (
+            <button
+              type="button"
+              className="hidden md:flex p-2 rounded-lg hover:bg-slate-100 text-slate-600"
+              onClick={onCollapse}
+              aria-label="サイドバーを折りたたむ"
+              title="サイドバーを折りたたむ"
+            >
+              <MdChevronLeft className="text-lg" />
+            </button>
+          )}
         </div>
       )}
       {/* データセット */}

--- a/stock_search/src/pages/DataPage.tsx
+++ b/stock_search/src/pages/DataPage.tsx
@@ -6,6 +6,7 @@ import {
   MdError,
   MdDescription,
   MdStar,
+  MdChevronRight,
 } from "react-icons/md";
 import { CSV_FILE_CONFIG } from "../constants/csv";
 import { Sidebar } from "../components/Sidebar";
@@ -31,10 +32,29 @@ interface CSVFile {
   url: string;
 }
 
+const SIDEBAR_STORAGE_KEY = "sidebarCollapsed";
+
+function getInitialSidebarCollapsed(): boolean {
+  try {
+    return localStorage.getItem(SIDEBAR_STORAGE_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
 export const DataPage = () => {
   const [selectedFile, setSelectedFile] = useState<CSVFile | null>(null);
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(getInitialSidebarCollapsed);
   const mainFileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(SIDEBAR_STORAGE_KEY, String(sidebarCollapsed));
+    } catch {
+      /* ignore */
+    }
+  }, [sidebarCollapsed]);
 
   const handleFileUpload = (file: File) => {
     setSelectedFile({
@@ -180,10 +200,31 @@ export const DataPage = () => {
       )}
 
       <div className="flex flex-1 overflow-hidden min-h-0">
-        {/* デスクトップ: 常に表示 / モバイル: 非表示（ドロワーで開く） */}
-        <div className="hidden md:block flex-shrink-0">
-          <Sidebar {...sidebarProps} />
-        </div>
+        {/* デスクトップ: 開閉可能 / モバイル: 非表示（ドロワーで開く） */}
+        {!sidebarCollapsed && (
+          <div className="hidden md:block flex-shrink-0">
+            <Sidebar
+              {...sidebarProps}
+              onCollapse={() => setSidebarCollapsed(true)}
+            />
+          </div>
+        )}
+
+        {/* デスクトップ: 折りたたみ時に表示する展開タブ */}
+        {sidebarCollapsed && (
+          <div className="hidden md:flex w-12 flex-shrink-0 flex-col items-center border-r border-[var(--border)] bg-slate-50/50 py-4">
+            <button
+              type="button"
+              className="p-2 rounded-lg hover:bg-slate-200/80 text-slate-600 transition-colors"
+              onClick={() => setSidebarCollapsed(false)}
+              aria-label="サイドバーを開く"
+              title="フィルター・データセットを開く"
+            >
+              <MdChevronRight className="text-xl" />
+            </button>
+            <span className="mt-2 text-[10px] text-slate-500">開く</span>
+          </div>
+        )}
 
         <main className="flex-1 flex flex-col min-w-0 bg-white overflow-hidden">
           {/* モバイル: フィルターを開くボタン */}


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add sidebar collapse/expand functionality for desktop view

- Persist sidebar state using localStorage across sessions

- Display collapse button in sidebar header and expand tab when collapsed

- Refactor header to support both mobile close and desktop collapse buttons


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User clicks collapse button"] --> B["setSidebarCollapsed true"]
  B --> C["localStorage updated"]
  C --> D["Expand tab displayed"]
  E["User clicks expand button"] --> F["setSidebarCollapsed false"]
  F --> C
  G["Page load"] --> H["Read localStorage"]
  H --> I["Initialize sidebar state"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Sidebar.tsx</strong><dd><code>Add collapse button and refactor header</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

stock_search/src/components/Sidebar.tsx

<ul><li>Import <code>MdChevronLeft</code> icon for collapse button<br> <li> Add <code>onCollapse</code> callback prop to SidebarProps interface<br> <li> Refactor header section to display both close button (mobile) and <br>collapse button (desktop)<br> <li> Combine mobile close and desktop collapse buttons in unified header <br>with conditional rendering</ul>


</details>


  </td>
  <td><a href="https://github.com/testkun08080/yfinance-jp-screener/pull/18/files#diff-97e51da3c7d59950c558f6edbd02b9ab1ea55817c68a52457df5dd4337badc03">+28/-11</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DataPage.tsx</strong><dd><code>Implement sidebar collapse state and persistence</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

stock_search/src/pages/DataPage.tsx

<ul><li>Import <code>MdChevronRight</code> icon for expand button<br> <li> Add <code>SIDEBAR_STORAGE_KEY</code> constant and <code>getInitialSidebarCollapsed()</code> <br>function for localStorage persistence<br> <li> Add <code>sidebarCollapsed</code> state and useEffect hook to sync state with <br>localStorage<br> <li> Conditionally render sidebar based on <code>sidebarCollapsed</code> state<br> <li> Add expand tab with button that appears when sidebar is collapsed on <br>desktop<br> <li> Pass <code>onCollapse</code> callback to Sidebar component</ul>


</details>


  </td>
  <td><a href="https://github.com/testkun08080/yfinance-jp-screener/pull/18/files#diff-c470342bc34dd672b77f317bc03f6edc705c23c459316d582a985924224a802d">+45/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

