### PR TITLE
モバイル表示

### DIFF
--- a/stock_search/src/components/AppHeader.tsx
+++ b/stock_search/src/components/AppHeader.tsx
@@ -23,7 +23,7 @@ export const AppHeader = () => {
   }, []);
 
   return (
-    <header className="h-14 border-b border-[var(--border)] bg-white flex items-center justify-between px-6 flex-shrink-0 z-50">
+    <header className="sticky top-0 h-14 border-b border-[var(--border)] bg-white flex items-center justify-between px-6 flex-shrink-0 z-50">
       <Link
         to="/"
         className="flex items-center gap-3 no-underline text-inherit hover:opacity-90"

--- a/stock_search/src/components/Sidebar.tsx
+++ b/stock_search/src/components/Sidebar.tsx
@@ -154,8 +154,10 @@ export const Sidebar = ({
 
   return (
     <aside
-      className={`w-72 flex-shrink-0 border-r border-[var(--border)] bg-white flex flex-col h-full ${
-        isDrawer ? "shadow-xl" : ""
+      className={`flex-shrink-0 bg-white flex flex-col overflow-hidden ${
+        isDrawer
+          ? "w-full h-full rounded-t-2xl border-t border-[var(--border)] shadow-2xl"
+          : "w-72 h-full border-r border-[var(--border)]"
       }`}
     >
       {/* ヘッダー: モバイル閉じる / デスクトップ折りたたみ */}

--- a/stock_search/src/index.css
+++ b/stock_search/src/index.css
@@ -54,3 +54,26 @@ details>summary {
 details>summary::-webkit-details-marker {
   display: none;
 }
+
+@keyframes mobileSheetUp {
+  from {
+    transform: translateY(100%);
+  }
+
+  to {
+    transform: translateY(0);
+  }
+}
+
+.mobile-sheet-enter {
+  animation: mobileSheetUp 0.2s ease-out;
+}
+
+/* iOS Safariの入力フォーカス時ズームを防止 */
+@media (max-width: 767px) {
+  input:not([type="checkbox"]):not([type="radio"]),
+  select,
+  textarea {
+    font-size: 16px;
+  }
+}

--- a/stock_search/src/pages/DataPage.tsx
+++ b/stock_search/src/pages/DataPage.tsx
@@ -56,6 +56,33 @@ export const DataPage = () => {
     }
   }, [sidebarCollapsed]);
 
+  useEffect(() => {
+    if (!sidebarOpen) return;
+
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.body.style.overflow = originalOverflow;
+    };
+  }, [sidebarOpen]);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(min-width: 768px)");
+
+    const handleMediaChange = (event: MediaQueryListEvent) => {
+      if (event.matches) {
+        setSidebarOpen(false);
+      }
+    };
+
+    mediaQuery.addEventListener("change", handleMediaChange);
+
+    return () => {
+      mediaQuery.removeEventListener("change", handleMediaChange);
+    };
+  }, []);
+
   const handleFileUpload = (file: File) => {
     setSelectedFile({
       name: file.name,
@@ -180,16 +207,21 @@ export const DataPage = () => {
         }}
         className="hidden"
       />
-      {/* モバイル: サイドバーをドロワーで表示 */}
+      {/* モバイル: サイドバーを下から出るモーダルで表示 */}
       {sidebarOpen && (
-        <div className="fixed inset-0 z-40 md:hidden" role="presentation">
+        <div
+          className="fixed inset-0 z-40 md:hidden"
+          role="dialog"
+          aria-modal="true"
+          aria-label="フィルター・データセット"
+        >
           <button
             type="button"
             className="absolute inset-0 bg-black/50"
             aria-label="閉じる"
             onClick={() => setSidebarOpen(false)}
           />
-          <div className="absolute left-0 top-0 bottom-0 w-72 max-w-[85vw] bg-white z-50">
+          <div className="absolute inset-x-0 bottom-0 h-[82vh] z-50 mobile-sheet-enter">
             <Sidebar
               {...sidebarProps}
               onClose={() => setSidebarOpen(false)}


### PR DESCRIPTION
### **User description**
Improve mobile responsiveness by changing the sidebar to a bottom sheet modal, preventing input zoom, and fixing the header as per issue #20.

---
<p><a href="https://cursor.com/agents/bc-4665c25e-f0b8-49af-a0f1-9ab2c4e0f800"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4665c25e-f0b8-49af-a0f1-9ab2c4e0f800"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


___

### **PR Type**
Enhancement


___

### **Description**
- Convert mobile sidebar to bottom-sheet modal with slide-up animation

- Prevent input zoom on iOS by setting font-size to 16px

- Make header sticky to remain visible while scrolling

- Disable body scroll when sidebar modal is open

- Auto-close sidebar when resizing from mobile to desktop


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Mobile Sidebar"] -->|"Convert to bottom-sheet"| B["Bottom-sheet Modal"]
  B -->|"Add animation"| C["Slide-up Animation"]
  D["Input Elements"] -->|"Set font-size 16px"| E["Prevent iOS Zoom"]
  F["Header"] -->|"Add sticky positioning"| G["Fixed Header"]
  H["Body Scroll"] -->|"Disable when modal open"| I["Scroll Lock"]
  J["Viewport Resize"] -->|"Detect 768px breakpoint"| K["Auto-close Sidebar"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.css</strong><dd><code>Add mobile animations and prevent input zoom</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

stock_search/src/index.css

<ul><li>Add <code>mobileSheetUp</code> keyframe animation for bottom-sheet slide-up effect<br> <li> Add <code>.mobile-sheet-enter</code> class to apply animation<br> <li> Add media query for mobile devices to set input font-size to 16px, <br>preventing iOS Safari zoom on focus</ul>


</details>


  </td>
  <td><a href="https://github.com/testkun08080/yfinance-jp-screener/pull/21/files#diff-d9b17c7874a545277866cc9af2831044810863d86a3fac7c9ee63bba90b9ab75">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AppHeader.tsx</strong><dd><code>Make header sticky on scroll</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

stock_search/src/components/AppHeader.tsx

<ul><li>Add <code>sticky top-0</code> classes to header to keep it fixed at top while <br>scrolling</ul>


</details>


  </td>
  <td><a href="https://github.com/testkun08080/yfinance-jp-screener/pull/21/files#diff-823c079edc49b5e4d4ce2c78a03597b32e65ff580f93f2dc95c1a4855c7c7086">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Sidebar.tsx</strong><dd><code>Adapt sidebar styling for bottom-sheet modal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

stock_search/src/components/Sidebar.tsx

<ul><li>Update sidebar styling for drawer mode to use full width with rounded <br>top corners<br> <li> Change border from right to top and adjust shadow for bottom-sheet <br>appearance<br> <li> Maintain desktop layout with fixed width and right border</ul>


</details>


  </td>
  <td><a href="https://github.com/testkun08080/yfinance-jp-screener/pull/21/files#diff-97e51da3c7d59950c558f6edbd02b9ab1ea55817c68a52457df5dd4337badc03">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DataPage.tsx</strong><dd><code>Implement bottom-sheet modal with scroll lock and responsive behavior</code></dd></summary>
<hr>

stock_search/src/pages/DataPage.tsx

<ul><li>Add effect to disable body scroll when sidebar modal is open<br> <li> Add media query listener to auto-close sidebar when viewport resizes <br>to desktop (768px+)<br> <li> Update modal overlay role and aria attributes for accessibility<br> <li> Change sidebar container positioning from left-side to bottom with <br>full height<br> <li> Apply <code>mobile-sheet-enter</code> animation class to sidebar modal</ul>


</details>


  </td>
  <td><a href="https://github.com/testkun08080/yfinance-jp-screener/pull/21/files#diff-c470342bc34dd672b77f317bc03f6edc705c23c459316d582a985924224a802d">+35/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

