### PR TITLE
Compact data page toolbar (icon-only actions)

### DIFF
--- a/stock_search/src/App.tsx
+++ b/stock_search/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import { BrowserRouter as Router, Routes, Route, useLocation } from "react-router-dom";
 import { Suspense, lazy } from "react";
 import { AppHeader } from "./components/AppHeader";
 
@@ -7,24 +7,33 @@ const UsagePage = lazy(() => import("./pages/UsagePage").then((m) => ({ default:
 const AboutPage = lazy(() => import("./pages/AboutPage").then((m) => ({ default: m.AboutPage })));
 const NotFound = lazy(() => import("./pages/NotFound").then((m) => ({ default: m.NotFound })));
 
+function AppRoutes() {
+  const { pathname } = useLocation();
+  const showGlobalHeader = pathname !== "/";
+
+  return (
+    <div className="h-screen flex flex-col overflow-hidden bg-white">
+      {showGlobalHeader && <AppHeader />}
+      <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
+        <Suspense fallback={<div className="p-6 text-center text-slate-600">読み込み中...</div>}>
+          <div className="flex-1 min-h-0 flex flex-col min-w-0">
+            <Routes>
+              <Route path="/" element={<DataPage />} />
+              <Route path="/usage" element={<UsagePage />} />
+              <Route path="/about" element={<AboutPage />} />
+              <Route path="*" element={<NotFound />} />
+            </Routes>
+          </div>
+        </Suspense>
+      </div>
+    </div>
+  );
+}
+
 function App() {
   return (
     <Router>
-      <div className="h-screen flex flex-col overflow-hidden bg-white">
-        <AppHeader />
-        <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
-          <Suspense fallback={<div className="p-6 text-center text-slate-600">読み込み中...</div>}>
-            <div className="flex-1 min-h-0 flex flex-col min-w-0">
-              <Routes>
-                <Route path="/" element={<DataPage />} />
-                <Route path="/usage" element={<UsagePage />} />
-                <Route path="/about" element={<AboutPage />} />
-                <Route path="*" element={<NotFound />} />
-              </Routes>
-            </div>
-          </Suspense>
-        </div>
-      </div>
+      <AppRoutes />
     </Router>
   );
 }

--- a/stock_search/src/components/ColumnSelector.tsx
+++ b/stock_search/src/components/ColumnSelector.tsx
@@ -146,9 +146,7 @@ export const ColumnSelector: FC<ColumnSelectorProps> = ({
         }
       >
         <MdViewColumn className={variant === "iconOnly" ? "text-xl" : "text-lg"} />
-        {variant === "default" && (
-          <span className="whitespace-nowrap">{labelText}</span>
-        )}
+        {variant === "default" && <span className="whitespace-nowrap">{labelText}</span>}
       </button>
 
       {isOpen && (

--- a/stock_search/src/components/ColumnSelector.tsx
+++ b/stock_search/src/components/ColumnSelector.tsx
@@ -14,6 +14,8 @@ interface ColumnSelectorProps {
   columns: ColumnConfig[];
   onColumnChange: (key: string, visible: boolean) => void;
   onCategoryToggle: (category: string, visible: boolean) => void;
+  /** アイコンのみ（ツールバー用）。ラベルは title / aria-label に集約 */
+  variant?: "default" | "iconOnly";
 }
 
 const categoryLabels: Record<string, string> = {
@@ -28,6 +30,7 @@ export const ColumnSelector: FC<ColumnSelectorProps> = ({
   columns,
   onColumnChange,
   onCategoryToggle,
+  variant = "default",
 }) => {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -127,17 +130,25 @@ export const ColumnSelector: FC<ColumnSelectorProps> = ({
     </>
   );
 
+  const labelText = `表示列 (${visibleCount}/${totalCount})`;
+
   return (
     <>
       <button
         type="button"
         onClick={() => setIsOpen(true)}
-        className="flex items-center gap-2 px-3 md:px-4 py-2 border border-slate-200 rounded-lg text-sm font-semibold text-slate-600 hover:bg-slate-50 transition-colors cursor-pointer flex-shrink-0 min-h-10"
+        title={labelText}
+        aria-label={labelText}
+        className={
+          variant === "iconOnly"
+            ? "flex items-center justify-center w-9 h-9 shrink-0 border border-slate-200 rounded-lg text-slate-600 hover:bg-slate-50 transition-colors cursor-pointer"
+            : "flex items-center gap-2 px-3 md:px-4 py-2 border border-slate-200 rounded-lg text-sm font-semibold text-slate-600 hover:bg-slate-50 transition-colors cursor-pointer flex-shrink-0 min-h-10"
+        }
       >
-        <MdViewColumn className="text-lg" />
-        <span className="whitespace-nowrap">
-          表示列 ({visibleCount}/{totalCount})
-        </span>
+        <MdViewColumn className={variant === "iconOnly" ? "text-xl" : "text-lg"} />
+        {variant === "default" && (
+          <span className="whitespace-nowrap">{labelText}</span>
+        )}
       </button>
 
       {isOpen && (

--- a/stock_search/src/components/DownloadButton.tsx
+++ b/stock_search/src/components/DownloadButton.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { MdDownload } from "react-icons/md";
 import type { StockData } from "../types/stock";
 import type { ColumnConfig } from "./ColumnSelector";
 import {
@@ -15,6 +16,8 @@ interface DownloadButtonProps {
   fileName?: string;
   totalCount?: number;
   className?: string;
+  /** アイコンのみ（ツールバー用）。件数・説明は title に集約 */
+  variant?: "default" | "iconOnly";
 }
 
 export const DownloadButton: React.FC<DownloadButtonProps> = ({
@@ -23,6 +26,7 @@ export const DownloadButton: React.FC<DownloadButtonProps> = ({
   fileName = "stock_data",
   totalCount,
   className = "",
+  variant = "default",
 }) => {
   const [isDownloading, setIsDownloading] = useState(false);
   const [downloadMessage, setDownloadMessage] = useState<string | null>(null);
@@ -113,30 +117,58 @@ export const DownloadButton: React.FC<DownloadButtonProps> = ({
   const visibleColumnCount = columns.filter((col) => col.visible).length;
   const isDisabled = isDownloading || data.length === 0 || cooldownRemaining > 0;
 
+  const downloadTitle =
+    cooldownRemaining > 0
+      ? `クールダウン中: あと${Math.ceil(cooldownRemaining / 1000)}秒`
+      : `CSVファイルをダウンロード (${data.length}件, ${visibleColumnCount}列, 約${estimatedSize})`;
+
+  const ariaLabel =
+    variant === "iconOnly"
+      ? cooldownRemaining > 0
+        ? `CSVダウンロード: クールダウン あと${Math.ceil(cooldownRemaining / 1000)}秒`
+        : isDownloading
+          ? "CSVを生成中"
+          : `CSVダウンロード (${data.length}件)`
+      : undefined;
+
   return (
     <div className={`relative flex-shrink-0 ${className}`}>
       <button
         onClick={handleDownload}
         disabled={isDisabled}
-        className={`btn btn-outline btn-sm gap-1.5 md:gap-2 min-h-10 px-3 md:px-4 whitespace-nowrap inline-flex items-center ${
-          data.length === 0 ? "btn-disabled" : ""
-        } ${cooldownRemaining > 0 ? "btn-disabled opacity-60" : ""}`}
-        title={
-          cooldownRemaining > 0
-            ? `クールダウン中: あと${Math.ceil(cooldownRemaining / 1000)}秒`
-            : `CSVファイルをダウンロード (${data.length}件, ${visibleColumnCount}列, 約${estimatedSize})`
-        }
+        type="button"
+        aria-label={ariaLabel}
+        className={`btn btn-outline btn-sm inline-flex items-center justify-center ${
+          variant === "iconOnly"
+            ? "min-h-9 h-9 w-9 px-0 gap-0"
+            : "gap-1.5 md:gap-2 min-h-10 px-3 md:px-4 whitespace-nowrap"
+        } ${data.length === 0 ? "btn-disabled" : ""} ${
+          cooldownRemaining > 0 ? "btn-disabled opacity-60" : ""
+        }`}
+        title={downloadTitle}
       >
         {isDownloading ? (
-          <>
-            <span className="loading loading-spinner loading-xs"></span>
-            生成中...
-          </>
+          variant === "iconOnly" ? (
+            <span className="loading loading-spinner loading-xs" aria-hidden />
+          ) : (
+            <>
+              <span className="loading loading-spinner loading-xs"></span>
+              生成中...
+            </>
+          )
         ) : cooldownRemaining > 0 ? (
-          <>
-            ⏱️ CSV
-            <span className="text-xs opacity-70">{Math.ceil(cooldownRemaining / 1000)}秒</span>
-          </>
+          variant === "iconOnly" ? (
+            <span className="text-xs font-semibold tabular-nums" aria-hidden>
+              {Math.ceil(cooldownRemaining / 1000)}
+            </span>
+          ) : (
+            <>
+              ⏱️ CSV
+              <span className="text-xs opacity-70">{Math.ceil(cooldownRemaining / 1000)}秒</span>
+            </>
+          )
+        ) : variant === "iconOnly" ? (
+          <MdDownload className="text-xl shrink-0" aria-hidden />
         ) : (
           <>
             📥 CSVダウンロード

--- a/stock_search/src/components/Sidebar.tsx
+++ b/stock_search/src/components/Sidebar.tsx
@@ -1,8 +1,17 @@
-import { MdClose, MdChevronLeft, MdFolderOpen, MdExpandMore, MdFilterList } from "react-icons/md";
+import { Link, NavLink } from "react-router-dom";
+import {
+  MdClose,
+  MdChevronLeft,
+  MdFolderOpen,
+  MdExpandMore,
+  MdFilterList,
+  MdAnalytics,
+} from "react-icons/md";
 import type { SearchFilters as SearchFiltersType } from "../types/stock";
 import { CSV_FILE_CONFIG } from "../constants/csv";
 import { FILE_SIZE } from "../constants/formatting";
 import { FILTER_PRESETS } from "../constants/presets";
+import { NAVIGATION_ITEMS } from "../constants/ui";
 
 interface FileInfo {
   name: string;
@@ -147,32 +156,74 @@ export const Sidebar = ({
           : "w-72 h-full border-r border-[var(--border)]"
       }`}
     >
-      {/* ヘッダー: モバイル閉じる / デスクトップ折りたたみ */}
-      {(onClose || onCollapse) && (
-        <div className="flex items-center justify-end gap-1 p-2 border-b border-[var(--border)]">
-          {onClose && (
-            <button
-              type="button"
-              className="p-2 rounded-lg hover:bg-slate-100 text-slate-600"
-              onClick={onClose}
-              aria-label="閉じる"
-            >
-              <MdClose />
-            </button>
-          )}
-          {onCollapse && (
-            <button
-              type="button"
-              className="hidden md:flex p-2 rounded-lg hover:bg-slate-100 text-slate-600"
-              onClick={onCollapse}
-              aria-label="サイドバーを折りたたむ"
-              title="サイドバーを折りたたむ"
-            >
-              <MdChevronLeft className="text-lg" />
-            </button>
-          )}
+      {/* アプリ chrome（旧トップヘッダー相当）: ブランド・ナビ・閉じる/折りたたみ */}
+      <div className="flex-shrink-0 border-b border-[var(--border)] bg-white">
+        <div className="flex items-center gap-2 px-3 py-2 min-h-[44px]">
+          <Link
+            to="/"
+            className="flex items-center gap-2 min-w-0 flex-1 no-underline text-inherit hover:opacity-90"
+            aria-label="ホーム"
+            onClick={() => {
+              if (isDrawer && onClose) onClose();
+            }}
+          >
+            <div className="w-7 h-7 shrink-0 bg-[var(--primary)] rounded-lg flex items-center justify-center text-white">
+              <MdAnalytics className="text-lg" aria-hidden />
+            </div>
+            <span className="font-bold text-sm tracking-tight text-slate-800 truncate">
+              <span className="text-[var(--primary)]">yfsc</span>
+            </span>
+          </Link>
+          <div className="flex items-center gap-0.5 shrink-0">
+            {onCollapse && (
+              <button
+                type="button"
+                className="hidden md:flex p-2 rounded-lg hover:bg-slate-100 text-slate-600"
+                onClick={onCollapse}
+                aria-label="サイドバーを折りたたむ"
+                title="サイドバーを折りたたむ"
+              >
+                <MdChevronLeft className="text-lg" />
+              </button>
+            )}
+            {onClose && (
+              <button
+                type="button"
+                className="p-2 rounded-lg hover:bg-slate-100 text-slate-600 md:hidden"
+                onClick={onClose}
+                aria-label="閉じる"
+              >
+                <MdClose className="text-lg" />
+              </button>
+            )}
+          </div>
         </div>
-      )}
+        <nav
+          className="flex flex-wrap gap-x-1 gap-y-1 px-2 pb-2 border-t border-slate-100/90"
+          aria-label="サイト内"
+        >
+          {NAVIGATION_ITEMS.map((item) => (
+            <NavLink
+              key={item.path}
+              to={item.path}
+              end={item.path === "/"}
+              onClick={() => {
+                if (isDrawer && onClose) onClose();
+              }}
+              className={({ isActive }) =>
+                `inline-flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-semibold no-underline transition-colors ${
+                  isActive
+                    ? "bg-[var(--primary)]/12 text-[var(--primary)]"
+                    : "text-slate-600 hover:bg-slate-100"
+                }`
+              }
+            >
+              <span aria-hidden>{item.icon}</span>
+              <span className="truncate max-w-[9.5rem]">{item.label}</span>
+            </NavLink>
+          ))}
+        </nav>
+      </div>
       {/* データセット */}
       <div className="p-4 border-b border-[var(--border)]">
         <div className="flex items-center justify-between mb-3">

--- a/stock_search/src/pages/DataPage.tsx
+++ b/stock_search/src/pages/DataPage.tsx
@@ -551,10 +551,7 @@ export const DataPage = () => {
                       className="inline-flex items-center gap-1 text-slate-900 truncate"
                       title={listTab === "all" ? "総件数" : "お気に入り件数"}
                     >
-                      <MdNumbers
-                        className="text-slate-400 shrink-0 text-lg"
-                        aria-hidden
-                      />
+                      <MdNumbers className="text-slate-400 shrink-0 text-lg" aria-hidden />
                       {displayData.length.toLocaleString()}
                     </span>
                     {listTab === "all" && (

--- a/stock_search/src/pages/DataPage.tsx
+++ b/stock_search/src/pages/DataPage.tsx
@@ -9,6 +9,8 @@ import {
   MdChevronRight,
   MdInfoOutline,
   MdClose,
+  MdAnalytics,
+  MdNumbers,
 } from "react-icons/md";
 import { CSV_FILE_CONFIG } from "../constants/csv";
 import { Sidebar } from "../components/Sidebar";
@@ -342,7 +344,15 @@ export const DataPage = () => {
 
         {/* デスクトップ: 折りたたみ時に表示する展開タブ */}
         {sidebarCollapsed && (
-          <div className="hidden md:flex w-12 flex-shrink-0 flex-col items-center border-r border-[var(--border)] bg-slate-50/50 py-4">
+          <div className="hidden md:flex w-12 flex-shrink-0 flex-col items-center border-r border-[var(--border)] bg-slate-50/50 py-3 gap-2">
+            <Link
+              to="/"
+              className="p-1.5 rounded-lg hover:bg-slate-200/80 text-white bg-[var(--primary)] shadow-sm"
+              aria-label="ホーム"
+              title="yfsc ホーム"
+            >
+              <MdAnalytics className="text-lg" aria-hidden />
+            </Link>
             <button
               type="button"
               className="p-2 rounded-lg hover:bg-slate-200/80 text-slate-600 transition-colors"
@@ -352,20 +362,33 @@ export const DataPage = () => {
             >
               <MdChevronRight className="text-xl" />
             </button>
-            <span className="mt-2 text-[10px] text-slate-500">開く</span>
+            <span className="text-[9px] text-slate-500 text-center leading-tight px-0.5">開く</span>
           </div>
         )}
 
         <main className="flex-1 flex flex-col min-w-0 bg-white overflow-hidden">
           {/* モバイル: フィルターを開くボタン */}
-          <div className="md:hidden flex-shrink-0 px-3 py-2 border-b border-[var(--border)] bg-white flex items-center gap-2">
+          <div className="md:hidden flex-shrink-0 px-3 py-2 border-b border-[var(--border)] bg-white flex items-center justify-between gap-2 min-h-[52px]">
+            <Link
+              to="/"
+              className="flex items-center gap-2 shrink-0 no-underline text-inherit min-w-0"
+              aria-label="ホーム"
+            >
+              <div className="w-8 h-8 bg-[var(--primary)] rounded-lg flex items-center justify-center text-white shrink-0">
+                <MdAnalytics className="text-xl" aria-hidden />
+              </div>
+              <span className="font-bold text-sm text-slate-800 truncate">
+                <span className="text-[var(--primary)]">yfsc</span>
+              </span>
+            </Link>
             <button
               type="button"
-              className="flex items-center gap-2 px-3 py-2 rounded-lg border border-slate-200 text-sm font-semibold text-slate-700 hover:bg-slate-50"
+              className="flex items-center gap-2 px-3 py-2 rounded-lg border border-slate-200 text-sm font-semibold text-slate-700 hover:bg-slate-50 shrink-0"
               onClick={() => setSidebarOpen(true)}
             >
               <MdFilterList className="text-lg" />
-              フィルター・データセット
+              <span className="max-[380px]:hidden">フィルター・データセット</span>
+              <span className="hidden max-[380px]:inline">フィルター</span>
             </button>
           </div>
           {persistMessage && selectedFile && (
@@ -486,73 +509,83 @@ export const DataPage = () => {
           {selectedFile && !loading && !error && data.length > 0 && (
             <>
               {/* タブ: すべて / お気に入りのみ ＋ Main toolbar */}
-              <div className="px-3 md:px-6 py-3 md:py-4 border-b border-[var(--border)] flex flex-wrap items-center justify-between gap-3 flex-shrink-0">
-                <div className="flex items-center gap-4 md:gap-6">
-                  {/* リスト表示タブ */}
-                  <div className="flex rounded-lg border border-slate-200 p-0.5 bg-slate-50">
+              <div className="px-3 md:px-6 py-2 border-b border-[var(--border)] flex flex-wrap items-center justify-between gap-2 md:gap-3 flex-shrink-0">
+                <div className="flex items-center gap-2 md:gap-4 min-w-0 flex-1">
+                  {/* リスト表示タブ（アイコン＋ title） */}
+                  <div className="flex rounded-lg border border-slate-200 p-0.5 bg-slate-50 shrink-0">
                     <button
                       type="button"
-                      className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+                      title="すべての銘柄を表示"
+                      aria-label="すべての銘柄を表示"
+                      className={`p-1.5 rounded-md transition-colors flex items-center justify-center ${
                         listTab === "all"
                           ? "bg-white text-slate-800 shadow-sm"
                           : "text-slate-600 hover:text-slate-800"
                       }`}
                       onClick={() => setListTab("all")}
                     >
-                      すべて
+                      <MdTableChart className="text-xl" aria-hidden />
                     </button>
                     <button
                       type="button"
-                      className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors flex items-center gap-1.5 ${
+                      title="お気に入りのみ表示"
+                      aria-label={`お気に入りのみ${favoritesInData.length > 0 ? ` (${favoritesInData.length}件)` : ""}`}
+                      className={`p-1.5 rounded-md transition-colors flex items-center justify-center gap-0.5 min-w-[2.25rem] ${
                         listTab === "favorites"
                           ? "bg-white text-amber-700 shadow-sm"
                           : "text-slate-600 hover:text-slate-800"
                       }`}
                       onClick={() => setListTab("favorites")}
                     >
-                      <MdStar className="text-amber-500 text-base" />
-                      お気に入りのみ
+                      <MdStar className="text-amber-500 text-lg shrink-0" aria-hidden />
                       {favoritesInData.length > 0 && (
-                        <span className="text-xs">({favoritesInData.length})</span>
+                        <span className="text-[10px] font-bold leading-none tabular-nums">
+                          {favoritesInData.length}
+                        </span>
                       )}
                     </button>
                   </div>
-                  <div className="w-[1px] h-10 bg-slate-100 hidden sm:block" />
-                  <div className="flex items-center gap-6 md:gap-10">
-                    <div>
-                      <p className="text-[11px] font-bold text-slate-400 uppercase tracking-tight">
-                        {listTab === "all" ? "総件数" : "お気に入り"}
-                      </p>
-                      <p className="text-2xl md:text-3xl font-bold text-slate-900">
-                        {displayData.length.toLocaleString()}
-                      </p>
-                    </div>
+                  <div className="w-px h-7 bg-slate-100 hidden sm:block shrink-0" />
+                  <div className="flex items-center gap-2 md:gap-4 min-w-0 text-sm md:text-base font-bold tabular-nums">
+                    <span
+                      className="inline-flex items-center gap-1 text-slate-900 truncate"
+                      title={listTab === "all" ? "総件数" : "お気に入り件数"}
+                    >
+                      <MdNumbers
+                        className="text-slate-400 shrink-0 text-lg"
+                        aria-hidden
+                      />
+                      {displayData.length.toLocaleString()}
+                    </span>
                     {listTab === "all" && (
                       <>
-                        <div className="w-[1px] h-10 bg-slate-100" />
-                        <div>
-                          <p className="text-[11px] font-bold text-[var(--primary)] uppercase tracking-tight">
-                            絞り込み結果
-                          </p>
-                          <p className="text-2xl md:text-3xl font-bold text-[var(--primary)]">
-                            {filteredData.length.toLocaleString()}
-                          </p>
-                        </div>
+                        <span className="text-slate-200 shrink-0" aria-hidden>
+                          |
+                        </span>
+                        <span
+                          className="inline-flex items-center gap-1 text-[var(--primary)] truncate"
+                          title="絞り込み結果"
+                        >
+                          <MdFilterList className="shrink-0 text-lg" aria-hidden />
+                          {filteredData.length.toLocaleString()}
+                        </span>
                       </>
                     )}
                   </div>
                 </div>
-                <div className="flex items-center gap-3">
+                <div className="flex items-center gap-2 shrink-0">
                   <ColumnSelector
                     columns={columns}
                     onColumnChange={handleColumnChange}
                     onCategoryToggle={handleCategoryToggle}
+                    variant="iconOnly"
                   />
                   <DownloadButton
                     data={displayData}
                     columns={columns}
                     fileName={selectedFile.name.replace(/\.[^/.]+$/, "")}
                     totalCount={data.length}
+                    variant="iconOnly"
                   />
                 </div>
               </div>


### PR DESCRIPTION
Reduces vertical space on the data view toolbar.

- DataPage: icon tabs for all/favorites, single-line counts with tooltips, tighter padding
- ColumnSelector / DownloadButton: optional `iconOnly` variant (used on DataPage; CSVViewer unchanged)

Made with [Cursor](https://cursor.com)