### PR TITLE
feat(stock_search): custom filter presets and screening UI

### DIFF
--- a/stock_search/src/components/Sidebar.tsx
+++ b/stock_search/src/components/Sidebar.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from "react";
 import { Link, NavLink } from "react-router-dom";
 import {
   MdClose,
@@ -6,11 +7,16 @@ import {
   MdExpandMore,
   MdFilterList,
   MdAnalytics,
+  MdBookmarkAdd,
 } from "react-icons/md";
-import type { SearchFilters as SearchFiltersType } from "../types/stock";
+import type { SearchFilters as SearchFiltersType, SavedFilterPreset } from "../types/stock";
 import { CSV_FILE_CONFIG } from "../constants/csv";
 import { FILE_SIZE } from "../constants/formatting";
 import { FILTER_PRESETS } from "../constants/presets";
+import {
+  loadHiddenBuiltinPresetIds,
+  persistHiddenBuiltinPresetIds,
+} from "../utils/builtinPresetHiddenStorage";
 import { NAVIGATION_ITEMS } from "../constants/ui";
 
 interface FileInfo {
@@ -35,6 +41,10 @@ interface SidebarProps {
   onFilterChange: (key: keyof SearchFiltersType, value: string | number | string[] | null) => void;
   onClearFilters: () => void;
   onApplyPreset?: (preset: Partial<SearchFiltersType>) => void;
+  customPresets?: SavedFilterPreset[];
+  onSaveCustomPreset?: (name: string) => string | null;
+  onApplyCustomPreset?: (preset: SavedFilterPreset) => void;
+  onDeleteCustomPreset?: (id: string) => void;
   availableIndustries: string[];
   availableMarkets: string[];
   availablePrefectures: string[];
@@ -102,6 +112,10 @@ export const Sidebar = ({
   onFilterChange,
   onClearFilters,
   onApplyPreset,
+  customPresets = [],
+  onSaveCustomPreset,
+  onApplyCustomPreset,
+  onDeleteCustomPreset,
   availableIndustries,
   availableMarkets,
   availablePrefectures,
@@ -109,6 +123,17 @@ export const Sidebar = ({
   isDrawer = false,
   onCollapse,
 }: SidebarProps) => {
+  const [savePresetModalOpen, setSavePresetModalOpen] = useState(false);
+  const [modalPresetName, setModalPresetName] = useState("");
+  const [modalPresetErr, setModalPresetErr] = useState<string | null>(null);
+  const [hiddenBuiltinPresetIds, setHiddenBuiltinPresetIds] = useState<string[]>(() =>
+    loadHiddenBuiltinPresetIds()
+  );
+
+  useEffect(() => {
+    persistHiddenBuiltinPresetIds(hiddenBuiltinPresetIds);
+  }, [hiddenBuiltinPresetIds]);
+
   const handleDatasetDrop = (e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
@@ -296,25 +321,80 @@ export const Sidebar = ({
           </div>
         </div>
 
-        {/* プリセットフィルター */}
+        {/* プリセットフィルター（標準＋マイプリセットを同一一覧） */}
         {onApplyPreset && (
           <div>
             <label className="text-[10px] font-bold text-slate-400 uppercase mb-2 block">
               スクリーニングプリセット
             </label>
             <div className="flex flex-wrap gap-1.5">
-              {FILTER_PRESETS.map((preset) => (
-                <button
+              {FILTER_PRESETS.filter((p) => !hiddenBuiltinPresetIds.includes(p.id)).map((preset) => (
+                <span
                   key={preset.id}
-                  type="button"
-                  title={preset.description}
-                  className="text-[11px] font-semibold px-2.5 py-1 rounded-full border border-[var(--primary)] text-[var(--primary)] hover:bg-[var(--primary)] hover:text-white transition-colors leading-tight"
-                  onClick={() => onApplyPreset(preset.filters)}
+                  className="inline-flex items-stretch rounded-full border border-[var(--primary)] text-[var(--primary)] overflow-hidden shadow-sm"
                 >
-                  {preset.label}
-                </button>
+                  <button
+                    type="button"
+                    title={preset.description}
+                    className="text-[11px] font-semibold px-2.5 py-1 leading-tight hover:bg-[var(--primary)] hover:text-white transition-colors"
+                    onClick={() => onApplyPreset(preset.filters)}
+                  >
+                    {preset.label}
+                  </button>
+                  <button
+                    type="button"
+                    className="px-1.5 border-l border-[var(--primary)]/25 text-slate-500 hover:bg-red-500 hover:text-white hover:border-red-500 transition-colors"
+                    title="一覧から削除（再表示は下部リンク）"
+                    aria-label={`「${preset.label}」を一覧から削除`}
+                    onClick={() =>
+                      setHiddenBuiltinPresetIds((prev) =>
+                        prev.includes(preset.id) ? prev : [...prev, preset.id]
+                      )
+                    }
+                  >
+                    <MdClose className="text-sm" aria-hidden />
+                  </button>
+                </span>
               ))}
+              {onApplyCustomPreset &&
+                onDeleteCustomPreset &&
+                customPresets.map((p) => (
+                  <span
+                    key={p.id}
+                    className="inline-flex items-stretch rounded-full border border-slate-300 text-slate-700 overflow-hidden shadow-sm"
+                  >
+                    <button
+                      type="button"
+                      title="この条件を適用"
+                      className="text-[11px] font-semibold px-2.5 py-1 leading-tight hover:bg-slate-700 hover:text-white transition-colors max-w-[10rem] truncate"
+                      onClick={() => {
+                        onApplyCustomPreset(p);
+                        if (isDrawer && onClose) onClose();
+                      }}
+                    >
+                      {p.label}
+                    </button>
+                    <button
+                      type="button"
+                      className="px-1.5 border-l border-slate-200 text-slate-500 hover:bg-red-500 hover:text-white hover:border-red-500 transition-colors"
+                      title="このプリセットを削除"
+                      aria-label={`「${p.label}」を削除`}
+                      onClick={() => onDeleteCustomPreset(p.id)}
+                    >
+                      <MdClose className="text-sm" aria-hidden />
+                    </button>
+                  </span>
+                ))}
             </div>
+            {hiddenBuiltinPresetIds.length > 0 && (
+              <button
+                type="button"
+                className="mt-2 text-[10px] font-semibold text-[var(--primary)] hover:underline"
+                onClick={() => setHiddenBuiltinPresetIds([])}
+              >
+                削除した標準プリセットをすべて再表示
+              </button>
+            )}
           </div>
         )}
 
@@ -631,16 +711,103 @@ export const Sidebar = ({
         </div>
       </div>
 
-      <div className="p-4 bg-slate-50 border-t border-[var(--border)]">
-        <button
-          type="button"
-          className="w-full bg-[var(--primary)] hover:bg-[var(--primary-hover)] text-white font-bold py-2.5 rounded-lg shadow-sm transition-all flex items-center justify-center gap-2 text-sm"
-          onClick={onClearFilters}
-        >
-          <MdFilterList className="text-lg" />
-          🗑️ フィルターをクリア
-        </button>
+      <div className="p-4 bg-slate-50 border-t border-[var(--border)] shrink-0">
+        <div className="flex gap-2">
+          <button
+            type="button"
+            className="flex-1 min-w-0 bg-[var(--primary)] hover:bg-[var(--primary-hover)] text-white font-bold py-2 rounded-lg shadow-sm transition-all flex items-center justify-center gap-1.5 text-[11px] sm:text-xs"
+            onClick={onClearFilters}
+          >
+            <MdFilterList className="text-base shrink-0" aria-hidden />
+            <span className="truncate">フィルターをクリア</span>
+          </button>
+          {onSaveCustomPreset && onApplyCustomPreset && onDeleteCustomPreset && (
+            <button
+              type="button"
+              className="flex-1 min-w-0 bg-white border-2 border-slate-200 hover:border-[var(--primary)] text-slate-700 hover:text-[var(--primary)] font-bold py-2 rounded-lg shadow-sm transition-all flex items-center justify-center gap-1.5 text-[11px] sm:text-xs"
+              title="現在の条件を名前を付けて保存"
+              onClick={() => {
+                setModalPresetName("");
+                setModalPresetErr(null);
+                setSavePresetModalOpen(true);
+              }}
+            >
+              <MdBookmarkAdd className="text-base shrink-0" aria-hidden />
+              <span className="truncate">条件を保存</span>
+            </button>
+          )}
+        </div>
       </div>
+
+      {savePresetModalOpen && onSaveCustomPreset && (
+        <div className="modal modal-open z-[200]" role="dialog" aria-modal="true" aria-labelledby="save-preset-title">
+          <div className="modal-box max-w-sm p-5 shadow-xl">
+            <h3 id="save-preset-title" className="font-bold text-base text-slate-800 mb-1">
+              マイプリセットに保存
+            </h3>
+            <p className="text-xs text-slate-500 mb-3">
+              表示中のフィルター条件を保存します。名前を入力して保存してください。
+            </p>
+            <label className="block text-[10px] font-bold text-slate-400 uppercase mb-1" htmlFor="save-preset-name">
+              プリセット名
+            </label>
+            <input
+              id="save-preset-name"
+              type="text"
+              className="input input-bordered input-sm w-full text-sm mb-2"
+              placeholder="例: 小型グロース"
+              maxLength={40}
+              autoFocus
+              value={modalPresetName}
+              onChange={(e) => {
+                setModalPresetName(e.target.value);
+                if (modalPresetErr) setModalPresetErr(null);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  const err = onSaveCustomPreset(modalPresetName);
+                  if (err) {
+                    setModalPresetErr(err);
+                    return;
+                  }
+                  setSavePresetModalOpen(false);
+                }
+              }}
+            />
+            {modalPresetErr && <p className="text-xs text-red-600 mb-2">{modalPresetErr}</p>}
+            <div className="modal-action mt-2 gap-2 flex-wrap sm:flex-nowrap">
+              <button
+                type="button"
+                className="btn btn-ghost btn-sm flex-1"
+                onClick={() => setSavePresetModalOpen(false)}
+              >
+                キャンセル
+              </button>
+              <button
+                type="button"
+                className="btn btn-primary btn-sm flex-1"
+                onClick={() => {
+                  const err = onSaveCustomPreset(modalPresetName);
+                  if (err) {
+                    setModalPresetErr(err);
+                    return;
+                  }
+                  setSavePresetModalOpen(false);
+                }}
+              >
+                保存する
+              </button>
+            </div>
+          </div>
+          <button
+            type="button"
+            className="modal-backdrop bg-black/50"
+            aria-label="閉じる"
+            onClick={() => setSavePresetModalOpen(false)}
+          />
+        </div>
+      )}
     </aside>
   );
 };

--- a/stock_search/src/hooks/useFilters.ts
+++ b/stock_search/src/hooks/useFilters.ts
@@ -1,7 +1,11 @@
 import { useState, useMemo, useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
-import type { StockData, SearchFilters, SortConfig } from "../types/stock";
+import type { StockData, SearchFilters, SortConfig, SavedFilterPreset } from "../types/stock";
 import { urlParamsToFilters, updateUrlWithFilters, generateShareUrl } from "../utils/urlParams";
+import {
+  loadCustomFilterPresets,
+  persistCustomFilterPresets,
+} from "../utils/customFilterPresetsStorage";
 
 /**
  * ティッカーシンボルから市場タイプを判定
@@ -92,6 +96,13 @@ export const useFilters = (data: StockData[]) => {
   const navigate = useNavigate();
   const [filters, setFilters] = useState<SearchFilters>(initialFilters);
   const [sortConfig, setSortConfig] = useState<SortConfig | null>(null);
+  const [customPresets, setCustomPresets] = useState<SavedFilterPreset[]>(() =>
+    loadCustomFilterPresets()
+  );
+
+  useEffect(() => {
+    persistCustomFilterPresets(customPresets);
+  }, [customPresets]);
 
   // 初回ロード時にURLパラメータからフィルターを復元
   useEffect(() => {
@@ -729,6 +740,37 @@ export const useFilters = (data: StockData[]) => {
     updateUrlWithFilters(newFilters);
   };
 
+  const MAX_CUSTOM_PRESETS = 30;
+  const MAX_CUSTOM_PRESET_LABEL = 40;
+
+  const applyCustomFilterPreset = (preset: SavedFilterPreset) => {
+    const merged: SearchFilters = {
+      ...initialFilters,
+      ...structuredClone(preset.filters),
+    };
+    setFilters(merged);
+    updateUrlWithFilters(merged);
+  };
+
+  const saveCustomFilterPreset = (label: string): string | null => {
+    const trimmed = label.trim();
+    if (!trimmed) return "名前を入力してください";
+    if (trimmed.length > MAX_CUSTOM_PRESET_LABEL) {
+      return `名前は${MAX_CUSTOM_PRESET_LABEL}文字以内にしてください`;
+    }
+    if (customPresets.length >= MAX_CUSTOM_PRESETS) {
+      return `マイプリセットは最大${MAX_CUSTOM_PRESETS}件までです`;
+    }
+    const id = `user-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+    const snapshot = structuredClone(filters) as SearchFilters;
+    setCustomPresets((prev) => [...prev, { id, label: trimmed, filters: snapshot }]);
+    return null;
+  };
+
+  const removeCustomFilterPreset = (id: string) => {
+    setCustomPresets((prev) => prev.filter((p) => p.id !== id));
+  };
+
   const shareFilters = () => {
     const shareUrl = generateShareUrl(filters);
     return shareUrl;
@@ -823,6 +865,10 @@ export const useFilters = (data: StockData[]) => {
     updateFilter,
     clearFilters,
     applyPreset,
+    customPresets,
+    saveCustomFilterPreset,
+    removeCustomFilterPreset,
+    applyCustomFilterPreset,
     handleSort,
     shareFilters,
     copyShareUrl,

--- a/stock_search/src/pages/DataPage.tsx
+++ b/stock_search/src/pages/DataPage.tsx
@@ -219,6 +219,10 @@ export const DataPage = () => {
     updateFilter,
     clearFilters,
     applyPreset,
+    customPresets,
+    saveCustomFilterPreset,
+    removeCustomFilterPreset,
+    applyCustomFilterPreset,
     handleSort,
   } = useFilters(data);
   const { favoriteCodesSet, toggle: onToggleFavorite } = useFavorites();
@@ -295,6 +299,10 @@ export const DataPage = () => {
     onFilterChange: updateFilter,
     onClearFilters: clearFilters,
     onApplyPreset: applyPreset,
+    customPresets,
+    onSaveCustomPreset: saveCustomFilterPreset,
+    onApplyCustomPreset: applyCustomFilterPreset,
+    onDeleteCustomPreset: removeCustomFilterPreset,
     availableIndustries: selectedFile ? availableIndustries : [],
     availableMarkets: selectedFile ? availableMarkets : [],
     availablePrefectures: selectedFile ? availablePrefectures : [],
@@ -549,10 +557,10 @@ export const DataPage = () => {
                   <div className="flex items-center gap-2 md:gap-4 min-w-0 text-sm md:text-base font-bold tabular-nums">
                     <span
                       className="inline-flex items-center gap-1 text-slate-900 truncate"
-                      title={listTab === "all" ? "総件数" : "お気に入り件数"}
+                      title={listTab === "all" ? "総件数（CSV 全行）" : "お気に入り件数"}
                     >
                       <MdNumbers className="text-slate-400 shrink-0 text-lg" aria-hidden />
-                      {displayData.length.toLocaleString()}
+                      {(listTab === "all" ? data.length : displayData.length).toLocaleString()}
                     </span>
                     {listTab === "all" && (
                       <>

--- a/stock_search/src/types/stock.ts
+++ b/stock_search/src/types/stock.ts
@@ -102,6 +102,13 @@ export interface SearchFilters {
   netCashRatioMax: number | null;
 }
 
+/** ユーザーが保存したスクリーニング条件（localStorage に永続化） */
+export interface SavedFilterPreset {
+  id: string;
+  label: string;
+  filters: SearchFilters;
+}
+
 export interface SortConfig {
   key: keyof StockData;
   direction: "asc" | "desc";

--- a/stock_search/src/utils/builtinPresetHiddenStorage.ts
+++ b/stock_search/src/utils/builtinPresetHiddenStorage.ts
@@ -1,0 +1,21 @@
+const STORAGE_KEY = "yfinance-jp-screener-hidden-builtin-presets";
+
+export function loadHiddenBuiltinPresetIds(): string[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((id): id is string => typeof id === "string");
+  } catch {
+    return [];
+  }
+}
+
+export function persistHiddenBuiltinPresetIds(ids: string[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([...new Set(ids)]));
+  } catch {
+    // quota / private mode
+  }
+}

--- a/stock_search/src/utils/customFilterPresetsStorage.ts
+++ b/stock_search/src/utils/customFilterPresetsStorage.ts
@@ -1,0 +1,41 @@
+import type { SavedFilterPreset, SearchFilters } from "../types/stock";
+
+const STORAGE_KEY = "yfinance-jp-screener-custom-filter-presets";
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null;
+}
+
+function looksLikeSearchFilters(obj: Record<string, unknown>): boolean {
+  return typeof obj.companyName === "string" && Array.isArray(obj.industries);
+}
+
+export function loadCustomFilterPresets(): SavedFilterPreset[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    const out: SavedFilterPreset[] = [];
+    for (const item of parsed) {
+      if (!isRecord(item)) continue;
+      const id = item.id;
+      const label = item.label;
+      const filters = item.filters;
+      if (typeof id !== "string" || typeof label !== "string" || !isRecord(filters)) continue;
+      if (!looksLikeSearchFilters(filters)) continue;
+      out.push({ id, label, filters: filters as unknown as SearchFilters });
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
+export function persistCustomFilterPresets(presets: SavedFilterPreset[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(presets));
+  } catch {
+    // quota / private mode
+  }
+}


### PR DESCRIPTION
## Summary

- **Custom filter presets**: Save the current filter state under a name (localStorage). Apply restores the full snapshot; delete removes the preset.
- **Screening preset row**: Built-in presets (バリュー株, etc.) and saved presets appear in the same `スクリーニングプリセット` list. Built-ins can be removed from the list (hidden IDs persisted); a link restores all built-ins.
- **Sidebar footer**: Clear filters and "条件を保存" side by side; save opens a naming modal.
- **Toolbar**: On the All tab, the first count shows total CSV rows (`data.length`); the second shows filtered count (`filteredData.length`).

## Files
- `stock_search/src/components/Sidebar.tsx`, `DataPage.tsx`
- `stock_search/src/hooks/useFilters.ts`
- `stock_search/src/types/stock.ts` (`SavedFilterPreset`)
- `stock_search/src/utils/customFilterPresetsStorage.ts`, `builtinPresetHiddenStorage.ts`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now create, save, and manage custom filter presets for quick reuse
  * Built-in filter presets can be individually hidden or restored
  * Custom presets appear alongside built-in presets with apply and delete actions
  * Modal dialog to save current filter conditions as a named preset with validation
  * Enhanced count display distinguishing total records from favorites

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/testkun08080/yfinance-jp-screener/pull/31)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->