### PR TITLE
動的スクリーニング（EDINET DB 風の条件追加 UI）

### DIFF
--- a/stock_search/package-lock.json
+++ b/stock_search/package-lock.json
@@ -33,7 +33,8 @@
         "prettier": "^3.5.3",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.39.1",
-        "vite": "^7.1.2"
+        "vite": "^7.1.2",
+        "vitest": "^3.2.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1137,9 +1138,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1152,9 +1150,6 @@
       "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1169,9 +1164,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1184,9 +1176,6 @@
       "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1201,9 +1190,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1216,9 +1202,6 @@
       "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1233,9 +1216,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1248,9 +1228,6 @@
       "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1265,9 +1242,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1280,9 +1254,6 @@
       "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1297,9 +1268,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1313,9 +1281,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1328,9 +1293,6 @@
       "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1723,6 +1685,24 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2066,6 +2046,121 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2128,6 +2223,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
@@ -2229,6 +2334,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2259,6 +2374,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2274,6 +2406,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chownr": {
@@ -2381,6 +2523,16 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2415,6 +2567,13 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
@@ -2663,6 +2822,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2671,6 +2840,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3312,6 +3491,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3523,6 +3709,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -3847,6 +4050,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3855,6 +4065,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
@@ -3868,6 +4092,26 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -3926,6 +4170,20 @@
         "node": ">=18"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -3969,6 +4227,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -4175,6 +4463,29 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/vite/node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -4204,6 +4515,92 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4218,6 +4615,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/stock_search/package.json
+++ b/stock_search/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.13",
@@ -37,6 +38,7 @@
     "prettier": "^3.5.3",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.39.1",
-    "vite": "^7.1.2"
+    "vite": "^7.1.2",
+    "vitest": "^3.2.4"
   }
 }

--- a/stock_search/src/components/CSVViewer.tsx
+++ b/stock_search/src/components/CSVViewer.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from "react";
 import { useCSVParser } from "../hooks/useCSVParser";
 import { useFilters } from "../hooks/useFilters";
-import { SearchFilters } from "./SearchFilters";
 import { DataTable } from "./DataTable";
 import { Pagination } from "./Pagination";
 import { ColumnSelector, type ColumnConfig } from "./ColumnSelector";
@@ -24,18 +23,7 @@ interface CSVViewerProps {
 
 export const CSVViewer = ({ file }: CSVViewerProps) => {
   const { data, loading, error, reload } = useCSVParser(file);
-  const {
-    filters,
-    filteredData,
-    sortConfig,
-    availableIndustries,
-    availableMarkets,
-    availablePrefectures,
-    updateFilter,
-    clearFilters,
-    handleSort,
-    // shareFilters, // コメントアウト: 共有機能は不要
-  } = useFilters(data);
+  const { filteredData, sortConfig, handleSort } = useFilters(data);
   const [paginationConfig, setPaginationConfig] = useState<PaginationConfig>({
     currentPage: 1,
     itemsPerPage: PAGINATION.defaultItemsPerPage,
@@ -171,16 +159,6 @@ export const CSVViewer = ({ file }: CSVViewerProps) => {
 
   return (
     <div className="space-y-6">
-      {/* 検索フィルター */}
-      <SearchFilters
-        filters={filters}
-        availableIndustries={availableIndustries}
-        availableMarkets={availableMarkets}
-        availablePrefectures={availablePrefectures}
-        onFilterChange={updateFilter}
-        onClearFilters={clearFilters}
-      />
-
       {/* ヘッダー情報とサマリー */}
       <div className="card bg-base-100 shadow-sm">
         <div className="card-body">

--- a/stock_search/src/components/ScreenerBar.tsx
+++ b/stock_search/src/components/ScreenerBar.tsx
@@ -1,0 +1,172 @@
+import { useState } from "react";
+import { MdAdd, MdFilterList, MdLink, MdSort } from "react-icons/md";
+import type { ScreenerCondition, ScreenerState } from "../types/stock";
+import type { ScreenerFieldMeta } from "../utils/screenerFieldRegistry";
+import { formatConditionSummary } from "../utils/screenerFieldRegistry";
+import { ScreenerConditionRow } from "./ScreenerConditionRow";
+
+interface ScreenerBarProps {
+  totalCount: number;
+  filteredCount: number;
+  screener: ScreenerState;
+  screenableFields: ScreenerFieldMeta[];
+  sortableKeys: string[];
+  onAddCondition: () => void;
+  onUpdateCondition: (id: string, patch: Partial<Omit<ScreenerCondition, "id">>) => void;
+  onRemoveCondition: (id: string) => void;
+  onClearConditions: () => void;
+  onClearAll: () => void;
+  onExcludeMissingChange: (value: boolean) => void;
+  onSetSort: (key: string, direction: "asc" | "desc") => void;
+  onCopyShareUrl: () => Promise<boolean>;
+}
+
+export function ScreenerBar({
+  totalCount,
+  filteredCount,
+  screener,
+  screenableFields,
+  sortableKeys,
+  onAddCondition,
+  onUpdateCondition,
+  onRemoveCondition,
+  onClearConditions,
+  onClearAll,
+  onExcludeMissingChange,
+  onSetSort,
+  onCopyShareUrl,
+}: ScreenerBarProps) {
+  const [copyOk, setCopyOk] = useState(false);
+
+  const handleCopy = async () => {
+    const ok = await onCopyShareUrl();
+    setCopyOk(ok);
+    if (ok) setTimeout(() => setCopyOk(false), 2000);
+  };
+
+  const sortKey = screener.sort?.key ? String(screener.sort.key) : "";
+  const sortDir = screener.sort?.direction ?? "desc";
+
+  return (
+    <section
+      className="flex-shrink-0 border-b border-[var(--border)] bg-slate-50/80 px-3 py-3 md:px-4 space-y-3"
+      aria-label="スクリーニング"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <h2 className="text-sm font-bold text-slate-800 flex items-center gap-1.5">
+            <MdFilterList className="text-[var(--primary)]" aria-hidden />
+            スクリーニング
+          </h2>
+          <p className="text-[11px] text-slate-500 mt-0.5">
+            全 <span className="font-semibold text-slate-700">{totalCount.toLocaleString()}</span> 件
+            → 絞り込み後{" "}
+            <span className="font-semibold text-[var(--primary)]">
+              {filteredCount.toLocaleString()}
+            </span>{" "}
+            件
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <label className="flex items-center gap-1.5 text-[11px] text-slate-600 cursor-pointer">
+            <input
+              type="checkbox"
+              className="checkbox checkbox-xs checkbox-primary"
+              checked={screener.excludeMissing}
+              onChange={(e) => onExcludeMissingChange(e.target.checked)}
+            />
+            値なしを除外
+          </label>
+          <button
+            type="button"
+            className="btn btn-ghost btn-xs gap-1"
+            onClick={handleCopy}
+            title="現在の条件でURLをコピー"
+          >
+            <MdLink className="text-sm" />
+            {copyOk ? "コピーしました" : "URL共有"}
+          </button>
+        </div>
+      </div>
+
+      <p className="text-[10px] text-slate-400 leading-snug">
+        yfinance 由来のデータです。指標はロードした CSV の列から選択できます。
+      </p>
+
+      {screener.conditions.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {screener.conditions.map((c) => {
+            const meta = screenableFields.find((f) => f.field === c.field);
+            return (
+              <span
+                key={c.id}
+                className="inline-flex items-center gap-1 text-[10px] font-medium px-2 py-0.5 rounded-full bg-white border border-slate-200 text-slate-600"
+              >
+                {formatConditionSummary(c, meta)}
+              </span>
+            );
+          })}
+        </div>
+      )}
+
+      <div className="space-y-2">
+        {screener.conditions.map((condition) => (
+          <ScreenerConditionRow
+            key={condition.id}
+            condition={condition}
+            fields={screenableFields}
+            onChange={(patch) => onUpdateCondition(condition.id, patch)}
+            onRemove={() => onRemoveCondition(condition.id)}
+          />
+        ))}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          className="btn btn-primary btn-sm gap-1 shadow-sm"
+          onClick={onAddCondition}
+          disabled={screenableFields.length === 0}
+        >
+          <MdAdd className="text-base" />
+          条件を追加
+        </button>
+        {screener.conditions.length > 0 && (
+          <button type="button" className="btn btn-ghost btn-sm" onClick={onClearConditions}>
+            条件のみクリア
+          </button>
+        )}
+        <button type="button" className="btn btn-ghost btn-sm" onClick={onClearAll}>
+          すべてクリア
+        </button>
+
+        <div className="flex items-center gap-1.5 ml-auto">
+          <MdSort className="text-slate-400 text-sm shrink-0" aria-hidden />
+          <select
+            className="select select-bordered select-xs max-w-[10rem]"
+            value={sortKey}
+            onChange={(e) => onSetSort(e.target.value, sortDir)}
+            aria-label="ソート列"
+          >
+            <option value="">ソートなし</option>
+            {sortableKeys.map((k) => (
+              <option key={k} value={k}>
+                {k}
+              </option>
+            ))}
+          </select>
+          <select
+            className="select select-bordered select-xs"
+            value={sortDir}
+            disabled={!sortKey}
+            onChange={(e) => onSetSort(sortKey, e.target.value as "asc" | "desc")}
+            aria-label="ソート順"
+          >
+            <option value="desc">降順</option>
+            <option value="asc">昇順</option>
+          </select>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/stock_search/src/components/ScreenerConditionRow.tsx
+++ b/stock_search/src/components/ScreenerConditionRow.tsx
@@ -1,0 +1,115 @@
+import type { ScreenerCondition, ScreenerOperator } from "../types/stock";
+import type { ScreenerFieldMeta } from "../utils/screenerFieldRegistry";
+import { OPERATOR_LABELS } from "../utils/screenerFieldRegistry";
+import { MdClose } from "react-icons/md";
+
+interface ScreenerConditionRowProps {
+  condition: ScreenerCondition;
+  fields: ScreenerFieldMeta[];
+  onChange: (patch: Partial<Omit<ScreenerCondition, "id">>) => void;
+  onRemove: () => void;
+}
+
+const OPERATORS: ScreenerOperator[] = ["gte", "lte", "between", "eq"];
+
+export function ScreenerConditionRow({
+  condition,
+  fields,
+  onChange,
+  onRemove,
+}: ScreenerConditionRowProps) {
+  const meta = fields.find((f) => f.field === condition.field) ?? fields[0];
+  const unit = meta?.unit ?? "";
+
+  const renderValueInputs = () => {
+    if (condition.operator === "between") {
+      const [min, max] = Array.isArray(condition.value) ? condition.value : [0, 0];
+      return (
+        <div className="flex items-center gap-1 flex-1 min-w-0">
+          <input
+            type="number"
+            className="text-[11px] p-1.5 border border-slate-200 rounded w-full min-w-0"
+            placeholder="最小"
+            value={min}
+            onChange={(e) =>
+              onChange({
+                value: [parseFloat(e.target.value) || 0, max],
+              })
+            }
+          />
+          <span className="text-slate-400 text-xs shrink-0">〜</span>
+          <input
+            type="number"
+            className="text-[11px] p-1.5 border border-slate-200 rounded w-full min-w-0"
+            placeholder="最大"
+            value={max}
+            onChange={(e) =>
+              onChange({
+                value: [min, parseFloat(e.target.value) || 0],
+              })
+            }
+          />
+        </div>
+      );
+    }
+    return (
+      <input
+        type="number"
+        className="text-[11px] p-1.5 border border-slate-200 rounded flex-1 min-w-0"
+        placeholder="値"
+        value={condition.value as number}
+        onChange={(e) => onChange({ value: parseFloat(e.target.value) || 0 })}
+      />
+    );
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 p-2 bg-slate-50 rounded-lg border border-slate-100">
+      <select
+        className="text-[11px] p-1.5 border border-slate-200 rounded bg-white min-w-[7rem] max-w-[10rem]"
+        value={condition.field}
+        onChange={(e) => onChange({ field: e.target.value })}
+        aria-label="指標"
+      >
+        {fields.map((f) => (
+          <option key={f.field} value={f.field}>
+            {f.label}
+          </option>
+        ))}
+      </select>
+      <select
+        className="text-[11px] p-1.5 border border-slate-200 rounded bg-white"
+        value={condition.operator}
+        onChange={(e) => {
+          const op = e.target.value as ScreenerOperator;
+          if (op === "between") {
+            const v = condition.value;
+            const num = typeof v === "number" ? v : Array.isArray(v) ? v[0] : 0;
+            onChange({ operator: op, value: [num, num] });
+          } else if (Array.isArray(condition.value)) {
+            onChange({ operator: op, value: condition.value[0] });
+          } else {
+            onChange({ operator: op });
+          }
+        }}
+        aria-label="演算子"
+      >
+        {OPERATORS.map((op) => (
+          <option key={op} value={op}>
+            {OPERATOR_LABELS[op]}
+          </option>
+        ))}
+      </select>
+      {renderValueInputs()}
+      {unit && <span className="text-[10px] text-slate-400 shrink-0">{unit}</span>}
+      <button
+        type="button"
+        className="p-1 rounded hover:bg-red-50 text-slate-400 hover:text-red-600 shrink-0"
+        onClick={onRemove}
+        aria-label="条件を削除"
+      >
+        <MdClose className="text-base" />
+      </button>
+    </div>
+  );
+}

--- a/stock_search/src/components/Sidebar.tsx
+++ b/stock_search/src/components/Sidebar.tsx
@@ -9,7 +9,8 @@ import {
   MdAnalytics,
   MdBookmarkAdd,
 } from "react-icons/md";
-import type { SearchFilters as SearchFiltersType, SavedFilterPreset } from "../types/stock";
+import type { ScreenerState, SavedFilterPreset, ScreenerCategoricalKey } from "../types/stock";
+import type { FilterPreset } from "../constants/presets";
 import { CSV_FILE_CONFIG } from "../constants/csv";
 import { FILE_SIZE } from "../constants/formatting";
 import { FILTER_PRESETS } from "../constants/presets";
@@ -37,10 +38,13 @@ interface SidebarProps {
   onClear: () => void;
   /** データ読み込み後、別のファイルを選択するためにファイルダイアログを開く */
   onOpenFileSelect?: () => void;
-  filters: SearchFiltersType;
-  onFilterChange: (key: keyof SearchFiltersType, value: string | number | string[] | null) => void;
+  filters: ScreenerState;
+  onFilterChange: (
+    key: ScreenerCategoricalKey | "companyName" | "stockCode",
+    value: string | number | string[] | boolean | null
+  ) => void;
   onClearFilters: () => void;
-  onApplyPreset?: (preset: Partial<SearchFiltersType>) => void;
+  onApplyPreset?: (preset: FilterPreset) => void;
   customPresets?: SavedFilterPreset[];
   onSaveCustomPreset?: (name: string) => string | null;
   onApplyCustomPreset?: (preset: SavedFilterPreset) => void;
@@ -54,52 +58,6 @@ interface SidebarProps {
   isDrawer?: boolean;
   /** デスクトップでサイドバーを折りたたむコールバック（指定時は折りたたみボタンを表示） */
   onCollapse?: () => void;
-}
-
-function NumRange({
-  label,
-  minKey,
-  maxKey,
-  unit = "",
-  filters,
-  onFilterChange,
-}: {
-  label: string;
-  minKey: keyof SearchFiltersType;
-  maxKey: keyof SearchFiltersType;
-  unit?: string;
-  filters: SearchFiltersType;
-  onFilterChange: SidebarProps["onFilterChange"];
-}) {
-  const minVal = filters[minKey] as number | null | undefined;
-  const maxVal = filters[maxKey] as number | null | undefined;
-  return (
-    <div>
-      <label className="text-[10px] font-bold text-slate-400 uppercase mb-1 block">
-        {label} {unit && `(${unit})`}
-      </label>
-      <div className="grid grid-cols-2 gap-2">
-        <input
-          type="number"
-          className="text-[11px] p-1.5 border border-slate-200 rounded w-full focus:ring-[var(--primary)] focus:border-[var(--primary)]"
-          placeholder="最小"
-          value={minVal ?? ""}
-          onChange={(e) =>
-            onFilterChange(minKey, e.target.value ? parseFloat(e.target.value) : null)
-          }
-        />
-        <input
-          type="number"
-          className="text-[11px] p-1.5 border border-slate-200 rounded w-full focus:ring-[var(--primary)] focus:border-[var(--primary)]"
-          placeholder="最大"
-          value={maxVal ?? ""}
-          onChange={(e) =>
-            onFilterChange(maxKey, e.target.value ? parseFloat(e.target.value) : null)
-          }
-        />
-      </div>
-    </div>
-  );
 }
 
 export const Sidebar = ({
@@ -337,7 +295,7 @@ export const Sidebar = ({
                     type="button"
                     title={preset.description}
                     className="text-[11px] font-semibold px-2.5 py-1 leading-tight hover:bg-[var(--primary)] hover:text-white transition-colors"
-                    onClick={() => onApplyPreset(preset.filters)}
+                    onClick={() => onApplyPreset(preset)}
                   >
                     {preset.label}
                   </button>
@@ -406,14 +364,6 @@ export const Sidebar = ({
               <MdExpandMore className="text-sm text-slate-400 group-open:rotate-180 transition-transform" />
             </summary>
             <div className="pt-2 space-y-4">
-              <NumRange
-                label="時価総額"
-                unit="百万円"
-                minKey="marketCapMin"
-                maxKey="marketCapMax"
-                filters={filters}
-                onFilterChange={onFilterChange}
-              />
               <div>
                 <label className="text-[10px] font-bold text-slate-400 uppercase mb-2 block">
                   業種
@@ -484,230 +434,9 @@ export const Sidebar = ({
             </div>
           </details>
 
-          {/* バリュエーション */}
-          <details className="group border-b border-slate-100 pb-2">
-            <summary className="flex items-center justify-between py-2 cursor-pointer">
-              <span className="text-xs font-bold text-slate-700">📊 バリュエーション</span>
-              <MdExpandMore className="text-sm text-slate-400 group-open:rotate-180 transition-transform" />
-            </summary>
-            <div className="pt-2 space-y-4">
-              <NumRange
-                label="PBR"
-                minKey="pbrMin"
-                maxKey="pbrMax"
-                filters={filters}
-                onFilterChange={onFilterChange}
-              />
-              <NumRange
-                label="ROE"
-                unit="%"
-                minKey="roeMin"
-                maxKey="roeMax"
-                filters={filters}
-                onFilterChange={onFilterChange}
-              />
-              <NumRange
-                label="自己資本比率"
-                unit="%"
-                minKey="equityRatioMin"
-                maxKey="equityRatioMax"
-                filters={filters}
-                onFilterChange={onFilterChange}
-              />
-              <NumRange
-                label="PER(会予)"
-                minKey="forwardPEMin"
-                maxKey="forwardPEMax"
-                filters={filters}
-                onFilterChange={onFilterChange}
-              />
-              <NumRange
-                label="PER(過去12ヶ月)"
-                minKey="trailingPEMin"
-                maxKey="trailingPEMax"
-                filters={filters}
-                onFilterChange={onFilterChange}
-              />
-              <NumRange
-                label="PER(前年度)"
-                minKey="previousYearPEMin"
-                maxKey="previousYearPEMax"
-                filters={filters}
-                onFilterChange={onFilterChange}
-              />
-              <NumRange
-                label="配当性向"
-                unit="%"
-                minKey="dividendDirectionMin"
-                maxKey="dividendDirectionMax"
-                filters={filters}
-                onFilterChange={onFilterChange}
-              />
-              <NumRange
-                label="配当利回り"
-                unit="%"
-                minKey="dividendYieldMin"
-                maxKey="dividendYieldMax"
-                filters={filters}
-                onFilterChange={onFilterChange}
-              />
-              <NumRange
-                label="EPS(過去12ヶ月)"
-                minKey="trailingEpsMin"
-                maxKey="trailingEpsMax"
-                filters={filters}
-                onFilterChange={onFilterChange}
-              />
-              <NumRange
-                label="EPS(予想)"
-                minKey="forwardEpsMin"
-                maxKey="forwardEpsMax"
-                filters={filters}
-                onFilterChange={onFilterChange}
-              />
-              <NumRange
-                label="EPS(前年度)"
-                minKey="previousYearEpsMin"
-                maxKey="previousYearEpsMax"
-                filters={filters}
-                onFilterChange={onFilterChange}
-              />
-            </div>
-          </details>
-
-          {/* 業績 */}
-          <details className="group border-b border-slate-100 pb-2">
-            <summary className="flex items-center justify-between py-2 cursor-pointer">
-              <span className="text-xs font-bold text-slate-700">💹 業績・収益性</span>
-              <MdExpandMore className="text-sm text-slate-400 group-open:rotate-180 transition-transform" />
-            </summary>
-            <div className="pt-2 space-y-4">
-              <NumRange
-                label="売上高"
-                unit="百万円"
-                minKey="revenueMin"
-                maxKey="revenueMax"
-                filters={filters}
-                onFilterChange={onFilterChange}
-              />
-              <NumRange
-                label="営業利益"
-                unit="百万円"
-                minKey="operatingProfitMin"
-                maxKey="operatingProfitMax"
-                filters={filters}
-                onFilterChange={onFilterChange}
-              />
-              <NumRange
-                label="営業利益率"
-                unit="%"
-                minKey="operatingMarginMin"
-                maxKey="operatingMarginMax"
-                filters={filters}
-                onFilterChange={onFilterChange}
-              />
-              <NumRange
-                label="当期純利益"
-                unit="百万円"
-                minKey="netProfitMin"
-                maxKey="netProfitMax"
-                filters={filters}
-                onFilterChange={onFilterChange}
-              />
-              <NumRange
-                label="純利益率"
-                unit="%"
-                minKey="netMarginMin"
-                maxKey="netMarginMax"
-                filters={filters}
-                onFilterChange={onFilterChange}
-              />
-            </div>
-          </details>
-
-          {/* バランスシート */}
-          <details className="group border-b border-slate-100 pb-2">
-            <summary className="flex items-center justify-between py-2 cursor-pointer">
-              <span className="text-xs font-bold text-slate-700">🏛️ バランスシート</span>
-              <MdExpandMore className="text-sm text-slate-400 group-open:rotate-180 transition-transform" />
-            </summary>
-            <div className="pt-2 space-y-4">
-              <NumRange
-                label="負債"
-                unit="百万円"
-                minKey="totalLiabilitiesMin"
-                maxKey="totalLiabilitiesMax"
-                filters={filters}
-                onFilterChange={onFilterChange}
-              />
-              <NumRange
-                label="流動負債"
-                unit="百万円"
-                minKey="currentLiabilitiesMin"
-                maxKey="currentLiabilitiesMax"
-                filters={filters}
-                onFilterChange={onFilterChange}
-              />
-              <NumRange
-                label="流動資産"
-                unit="百万円"
-                minKey="currentAssetsMin"
-                maxKey="currentAssetsMax"
-                filters={filters}
-                onFilterChange={onFilterChange}
-              />
-              <NumRange
-                label="総負債"
-                unit="百万円"
-                minKey="totalDebtMin"
-                maxKey="totalDebtMax"
-                filters={filters}
-                onFilterChange={onFilterChange}
-              />
-              <NumRange
-                label="投資有価証券"
-                unit="百万円"
-                minKey="investmentsMin"
-                maxKey="investmentsMax"
-                filters={filters}
-                onFilterChange={onFilterChange}
-              />
-            </div>
-          </details>
-
-          {/* キャッシュ */}
-          <details className="group border-b border-slate-100 pb-2">
-            <summary className="flex items-center justify-between py-2 cursor-pointer">
-              <span className="text-xs font-bold text-slate-700">💰 キャッシュ</span>
-              <MdExpandMore className="text-sm text-slate-400 group-open:rotate-180 transition-transform" />
-            </summary>
-            <div className="pt-2 space-y-4">
-              <NumRange
-                label="現金及び現金同等物"
-                unit="百万円"
-                minKey="cashMin"
-                maxKey="cashMax"
-                filters={filters}
-                onFilterChange={onFilterChange}
-              />
-              <NumRange
-                label="ネットキャッシュ"
-                unit="百万円"
-                minKey="netCashMin"
-                maxKey="netCashMax"
-                filters={filters}
-                onFilterChange={onFilterChange}
-              />
-              <NumRange
-                label="ネットキャッシュ比率"
-                unit="%"
-                minKey="netCashRatioMin"
-                maxKey="netCashRatioMax"
-                filters={filters}
-                onFilterChange={onFilterChange}
-              />
-            </div>
-          </details>
+        <p className="text-[10px] text-slate-500 px-0.5 pb-2">
+          数値条件はメイン画面の「＋ 条件を追加」から設定できます。
+        </p>
         </div>
       </div>
 

--- a/stock_search/src/constants/presets.ts
+++ b/stock_search/src/constants/presets.ts
@@ -1,10 +1,23 @@
-import type { SearchFilters } from "../types/stock";
+import type { ScreenerCondition } from "../types/stock";
 
 export interface FilterPreset {
   id: string;
   label: string;
   description: string;
-  filters: Partial<SearchFilters>;
+  conditions: ScreenerCondition[];
+}
+
+function cond(
+  field: string,
+  operator: ScreenerCondition["operator"],
+  value: ScreenerCondition["value"]
+): ScreenerCondition {
+  return {
+    id: `preset-${field}-${operator}`,
+    field,
+    operator,
+    value,
+  };
 }
 
 export const FILTER_PRESETS: FilterPreset[] = [
@@ -12,43 +25,30 @@ export const FILTER_PRESETS: FilterPreset[] = [
     id: "value",
     label: "バリュー株",
     description: "PBR 1倍未満 ＋ ROE 8%以上の割安・高収益株",
-    filters: {
-      pbrMax: 1.0,
-      roeMin: 8,
-    },
+    conditions: [cond("PBR", "lte", 1.0), cond("ROE", "gte", 8)],
   },
   {
     id: "high-dividend",
     label: "高配当",
     description: "配当利回り 3%以上の高配当銘柄",
-    filters: {
-      dividendYieldMin: 3,
-    },
+    conditions: [cond("配当利回り", "gte", 3)],
   },
   {
     id: "net-cash",
     label: "ネットキャッシュ豊富",
     description: "ネットキャッシュ比率 50%以上（現金が時価総額の半分超）",
-    filters: {
-      netCashRatioMin: 50,
-    },
+    conditions: [cond("ネットキャッシュ比率", "gte", 50)],
   },
   {
     id: "quality",
     label: "優良収益",
     description: "営業利益率10%以上 ＋ 自己資本比率50%以上の財務健全株",
-    filters: {
-      operatingMarginMin: 10,
-      equityRatioMin: 50,
-    },
+    conditions: [cond("営業利益率", "gte", 10), cond("自己資本比率", "gte", 50)],
   },
   {
     id: "low-pbr-high-roe",
     label: "低PBR高ROE",
     description: "PBR 1.5倍未満 ＋ ROE 15%以上。割安かつ高収益の優良株",
-    filters: {
-      pbrMax: 1.5,
-      roeMin: 15,
-    },
+    conditions: [cond("PBR", "lte", 1.5), cond("ROE", "gte", 15)],
   },
 ];

--- a/stock_search/src/hooks/useFilters.ts
+++ b/stock_search/src/hooks/useFilters.ts
@@ -1,755 +1,172 @@
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo, useEffect, useCallback } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
-import type { StockData, SearchFilters, SortConfig, SavedFilterPreset } from "../types/stock";
-import { urlParamsToFilters, updateUrlWithFilters, generateShareUrl } from "../utils/urlParams";
+import type {
+  StockData,
+  ScreenerState,
+  ScreenerCondition,
+  ScreenerCategoricalKey,
+  SavedFilterPreset,
+  SortConfig,
+} from "../types/stock";
+import { mergeUrlIntoScreener, updateUrlWithScreener, generateShareUrl } from "../utils/urlParams";
 import {
   loadCustomFilterPresets,
   persistCustomFilterPresets,
 } from "../utils/customFilterPresetsStorage";
-
-/**
- * ティッカーシンボルから市場タイプを判定
- */
-function detectMarketTypeFromTicker(ticker: string): "JP" | "US" {
-  if (!ticker) return "JP"; // デフォルトは日本株
-
-  const tickerStr = String(ticker).trim();
-
-  // 日本株判定: .Tで終わる、または4桁の数値コード
-  if (tickerStr.endsWith(".T")) {
-    return "JP";
-  }
-  if (/^\d{4}$/.test(tickerStr)) {
-    return "JP";
-  }
-
-  // 米国株判定: 1-5文字の英字（.Tで終わらない）
-  if (/^[A-Z]{1,5}$/i.test(tickerStr)) {
-    return "US";
-  }
-
-  // デフォルトは日本株（後方互換性のため）
-  return "JP";
-}
-
-const initialFilters: SearchFilters = {
-  companyName: "",
-  stockCode: "",
-  industries: [],
-  market: [],
-  marketType: ["JP", "US"], // デフォルトは両方選択
-  prefecture: [],
-  marketCapMin: null,
-  marketCapMax: null,
-  pbrMin: null,
-  pbrMax: null,
-  roeMin: null,
-  roeMax: null,
-  revenueMin: null,
-  revenueMax: null,
-  operatingProfitMin: null,
-  operatingProfitMax: null,
-  operatingMarginMin: null,
-  operatingMarginMax: null,
-  netProfitMin: null,
-  netProfitMax: null,
-  netMarginMin: null,
-  netMarginMax: null,
-  equityRatioMin: null,
-  equityRatioMax: null,
-  forwardPEMin: null,
-  forwardPEMax: null,
-  trailingPEMin: null,
-  trailingPEMax: null,
-  previousYearPEMin: null,
-  previousYearPEMax: null,
-  dividendDirectionMin: null,
-  dividendDirectionMax: null,
-  dividendYieldMin: null,
-  dividendYieldMax: null,
-  trailingEpsMin: null,
-  trailingEpsMax: null,
-  forwardEpsMin: null,
-  forwardEpsMax: null,
-  previousYearEpsMin: null,
-  previousYearEpsMax: null,
-  totalLiabilitiesMin: null,
-  totalLiabilitiesMax: null,
-  currentLiabilitiesMin: null,
-  currentLiabilitiesMax: null,
-  currentAssetsMin: null,
-  currentAssetsMax: null,
-  totalDebtMin: null,
-  totalDebtMax: null,
-  cashMin: null,
-  cashMax: null,
-  investmentsMin: null,
-  investmentsMax: null,
-  netCashMin: null,
-  netCashMax: null,
-  netCashRatioMin: null,
-  netCashRatioMax: null,
-};
+import { filterStocks, detectMarketTypeFromTicker } from "../utils/screenerEngine";
+import { initialScreenerState, searchFiltersToScreenerState } from "../utils/searchFiltersMigration";
+import { buildScreenableFields } from "../utils/screenerFieldRegistry";
 
 export const useFilters = (data: StockData[]) => {
   const location = useLocation();
   const navigate = useNavigate();
-  const [filters, setFilters] = useState<SearchFilters>(initialFilters);
-  const [sortConfig, setSortConfig] = useState<SortConfig | null>(null);
+  const [screener, setScreener] = useState<ScreenerState>(initialScreenerState);
   const [customPresets, setCustomPresets] = useState<SavedFilterPreset[]>(() =>
     loadCustomFilterPresets()
+  );
+
+  const availableColumns = useMemo(() => {
+    if (data.length === 0) return [] as string[];
+    return Object.keys(data[0]).filter((k) => !k.startsWith("_"));
+  }, [data]);
+
+  const screenableFields = useMemo(
+    () => buildScreenableFields(availableColumns, data[0] as Record<string, unknown> | undefined),
+    [availableColumns, data]
   );
 
   useEffect(() => {
     persistCustomFilterPresets(customPresets);
   }, [customPresets]);
 
-  // 初回ロード時にURLパラメータからフィルターを復元
   useEffect(() => {
     const searchParams = new URLSearchParams(location.search);
-    const urlFilters = urlParamsToFilters(searchParams);
-    if (Object.keys(urlFilters).length > 0) {
-      setFilters((prev) => ({ ...prev, ...urlFilters }));
-    }
+    if (searchParams.toString() === "") return;
+    setScreener((prev) => mergeUrlIntoScreener(prev, searchParams));
   }, [location.search]);
 
-  const filteredData = useMemo(() => {
-    const filtered = data.filter((stock) => {
-      // 会社名フィルター（数値など非文字列が入る場合に対応）
-      if (filters.companyName) {
-        const companyNameStr = String(stock.会社名 ?? "").toLowerCase();
-        if (!companyNameStr.includes(filters.companyName.toLowerCase())) {
-          return false;
-        }
-      }
+  const filteredData = useMemo(() => filterStocks(data, screener), [data, screener]);
 
-      // 銘柄コードフィルター
-      if (filters.stockCode) {
-        const stockCode = stock.銘柄コード || stock.コード || "";
-        if (!stockCode.toString().includes(filters.stockCode)) {
-          return false;
-        }
-      }
+  const sortConfig = screener.sort;
 
-      // 業種フィルター（複数選択）
-      if (filters.industries.length > 0 && !filters.industries.includes(stock.業種 || "")) {
-        return false;
-      }
+  const syncUrl = useCallback((next: ScreenerState) => {
+    updateUrlWithScreener(next);
+  }, []);
 
-      // 市場タイプフィルター（複数選択）
-      if (filters.marketType && filters.marketType.length > 0) {
-        const stockMarketType =
-          stock.市場タイプ || detectMarketTypeFromTicker(stock.銘柄コード || stock.コード || "");
-        if (!filters.marketType.includes(stockMarketType as "JP" | "US")) {
-          return false;
-        }
-      }
-
-      // 市場フィルター（複数選択）
-      if (filters.market.length > 0 && !filters.market.includes(stock.優先市場 || "")) {
-        return false;
-      }
-
-      // 都道府県フィルター（複数選択、日本株のみ）
-      if (filters.prefecture.length > 0) {
-        const stockMarketType =
-          stock.市場タイプ || detectMarketTypeFromTicker(stock.銘柄コード || stock.コード || "");
-        // 日本株の場合のみ都道府県フィルターを適用
-        if (stockMarketType === "JP" && !filters.prefecture.includes(stock.都道府県 || "")) {
-          return false;
-        }
-      }
-
-      // PBRフィルター（データがnull/undefinedの場合は含める）
-      if (
-        filters.pbrMin !== null &&
-        stock.PBR !== null &&
-        stock.PBR !== undefined &&
-        typeof stock.PBR === "number" &&
-        stock.PBR < filters.pbrMin
-      ) {
-        return false;
-      }
-      if (
-        filters.pbrMax !== null &&
-        stock.PBR !== null &&
-        stock.PBR !== undefined &&
-        typeof stock.PBR === "number" &&
-        stock.PBR > filters.pbrMax
-      ) {
-        return false;
-      }
-
-      // ROEフィルター（データがnull/undefinedの場合は含める）
-      if (
-        filters.roeMin !== null &&
-        stock.ROE !== null &&
-        stock.ROE !== undefined &&
-        typeof stock.ROE === "number" &&
-        stock.ROE < filters.roeMin / 100
-      ) {
-        return false;
-      }
-      if (
-        filters.roeMax !== null &&
-        stock.ROE !== null &&
-        stock.ROE !== undefined &&
-        typeof stock.ROE === "number" &&
-        stock.ROE > filters.roeMax / 100
-      ) {
-        return false;
-      }
-
-      // 時価総額フィルター（データがnull/undefinedの場合は含める）
-      if (
-        filters.marketCapMin !== null &&
-        stock.時価総額 !== null &&
-        stock.時価総額 !== undefined &&
-        typeof stock.時価総額 === "number" &&
-        stock.時価総額 < filters.marketCapMin * 1000000
-      ) {
-        return false;
-      }
-      if (
-        filters.marketCapMax !== null &&
-        stock.時価総額 !== null &&
-        stock.時価総額 !== undefined &&
-        typeof stock.時価総額 === "number" &&
-        stock.時価総額 > filters.marketCapMax * 1000000
-      ) {
-        return false;
-      }
-
-      // 売上高フィルター（データがnull/undefinedの場合は含める）
-      if (
-        filters.revenueMin !== null &&
-        stock.売上高 !== null &&
-        stock.売上高 !== undefined &&
-        typeof stock.売上高 === "number" &&
-        stock.売上高 < filters.revenueMin * 1000000
-      ) {
-        return false;
-      }
-      if (
-        filters.revenueMax !== null &&
-        stock.売上高 !== null &&
-        stock.売上高 !== undefined &&
-        typeof stock.売上高 === "number" &&
-        stock.売上高 > filters.revenueMax * 1000000
-      ) {
-        return false;
-      }
-
-      // 営業利益フィルター（データがnull/undefinedの場合は含める）
-      if (
-        filters.operatingProfitMin !== null &&
-        stock.営業利益 !== null &&
-        stock.営業利益 !== undefined &&
-        typeof stock.営業利益 === "number" &&
-        stock.営業利益 < filters.operatingProfitMin * 1000000
-      ) {
-        return false;
-      }
-      if (
-        filters.operatingProfitMax !== null &&
-        stock.営業利益 !== null &&
-        stock.営業利益 !== undefined &&
-        typeof stock.営業利益 === "number" &&
-        stock.営業利益 > filters.operatingProfitMax * 1000000
-      ) {
-        return false;
-      }
-
-      // 営業利益率フィルター（%）（データがnull/undefinedの場合は含める）
-      if (
-        filters.operatingMarginMin !== null &&
-        stock.営業利益率 !== null &&
-        stock.営業利益率 !== undefined &&
-        typeof stock.営業利益率 === "number" &&
-        stock.営業利益率 < filters.operatingMarginMin / 100
-      ) {
-        return false;
-      }
-      if (
-        filters.operatingMarginMax !== null &&
-        stock.営業利益率 !== null &&
-        stock.営業利益率 !== undefined &&
-        typeof stock.営業利益率 === "number" &&
-        stock.営業利益率 > filters.operatingMarginMax / 100
-      ) {
-        return false;
-      }
-
-      // 当期純利益フィルター（データがnull/undefinedの場合は含める）
-      if (
-        filters.netProfitMin !== null &&
-        stock.当期純利益 !== null &&
-        stock.当期純利益 !== undefined &&
-        typeof stock.当期純利益 === "number" &&
-        stock.当期純利益 < filters.netProfitMin * 1000000
-      ) {
-        return false;
-      }
-      if (
-        filters.netProfitMax !== null &&
-        stock.当期純利益 !== null &&
-        stock.当期純利益 !== undefined &&
-        typeof stock.当期純利益 === "number" &&
-        stock.当期純利益 > filters.netProfitMax * 1000000
-      ) {
-        return false;
-      }
-
-      // 純利益率フィルター（%）（データがnull/undefinedの場合は含める）
-      if (
-        filters.netMarginMin !== null &&
-        stock.純利益率 !== null &&
-        stock.純利益率 !== undefined &&
-        typeof stock.純利益率 === "number" &&
-        stock.純利益率 < filters.netMarginMin / 100
-      ) {
-        return false;
-      }
-      if (
-        filters.netMarginMax !== null &&
-        stock.純利益率 !== null &&
-        stock.純利益率 !== undefined &&
-        typeof stock.純利益率 === "number" &&
-        stock.純利益率 > filters.netMarginMax / 100
-      ) {
-        return false;
-      }
-
-      // 自己資本比率フィルター（%）（データがnull/undefinedの場合は含める）
-      if (
-        filters.equityRatioMin !== null &&
-        stock.自己資本比率 !== null &&
-        stock.自己資本比率 !== undefined &&
-        typeof stock.自己資本比率 === "number" &&
-        stock.自己資本比率 < filters.equityRatioMin / 100
-      ) {
-        return false;
-      }
-      if (
-        filters.equityRatioMax !== null &&
-        stock.自己資本比率 !== null &&
-        stock.自己資本比率 !== undefined &&
-        typeof stock.自己資本比率 === "number" &&
-        stock.自己資本比率 > filters.equityRatioMax / 100
-      ) {
-        return false;
-      }
-
-      // PER(会予)フィルター（データがnull/undefinedの場合は含める）
-      if (
-        filters.forwardPEMin !== null &&
-        stock["PER(会予)"] !== null &&
-        stock["PER(会予)"] !== undefined &&
-        typeof stock["PER(会予)"] === "number" &&
-        stock["PER(会予)"] < filters.forwardPEMin
-      ) {
-        return false;
-      }
-      if (
-        filters.forwardPEMax !== null &&
-        stock["PER(会予)"] !== null &&
-        stock["PER(会予)"] !== undefined &&
-        typeof stock["PER(会予)"] === "number" &&
-        stock["PER(会予)"] > filters.forwardPEMax
-      ) {
-        return false;
-      }
-
-      // PER（trailingPE）フィルター - 情報的に不確かなためコメントアウト
-      // if (
-      //   filters.trailingPEMin !== null &&
-      //   stock.PER !== null &&
-      //   stock.PER !== undefined &&
-      //   typeof stock.PER === "number" &&
-      //   stock.PER < filters.trailingPEMin
-      // ) {
-      //   return false;
-      // }
-      // if (
-      //   filters.trailingPEMax !== null &&
-      //   stock.PER !== null &&
-      //   stock.PER !== undefined &&
-      //   typeof stock.PER === "number" &&
-      //   stock.PER > filters.trailingPEMax
-      // ) {
-      //   return false;
-      // }
-
-      // PER(過去12ヶ月)フィルター（trailingPE、過去12ヶ月分）（データがnull/undefinedの場合は含める）
-      if (
-        filters.trailingPEMin !== null &&
-        stock["PER(過去12ヶ月)"] !== null &&
-        stock["PER(過去12ヶ月)"] !== undefined &&
-        typeof stock["PER(過去12ヶ月)"] === "number" &&
-        stock["PER(過去12ヶ月)"] < filters.trailingPEMin
-      ) {
-        return false;
-      }
-      if (
-        filters.trailingPEMax !== null &&
-        stock["PER(過去12ヶ月)"] !== null &&
-        stock["PER(過去12ヶ月)"] !== undefined &&
-        typeof stock["PER(過去12ヶ月)"] === "number" &&
-        stock["PER(過去12ヶ月)"] > filters.trailingPEMax
-      ) {
-        return false;
-      }
-
-      // PER(前年度)フィルター（データがnull/undefinedの場合は含める）
-      if (
-        filters.previousYearPEMin !== null &&
-        stock["PER(前年度)"] !== null &&
-        stock["PER(前年度)"] !== undefined &&
-        typeof stock["PER(前年度)"] === "number" &&
-        stock["PER(前年度)"] < filters.previousYearPEMin
-      ) {
-        return false;
-      }
-      if (
-        filters.previousYearPEMax !== null &&
-        stock["PER(前年度)"] !== null &&
-        stock["PER(前年度)"] !== undefined &&
-        typeof stock["PER(前年度)"] === "number" &&
-        stock["PER(前年度)"] > filters.previousYearPEMax
-      ) {
-        return false;
-      }
-
-      // 配当方向性フィルター（%）（データがnull/undefinedの場合は含める）
-      // フィルター値は%で入力されるが、データは小数（0.3 = 30%）で保存されているため変換
-      if (
-        filters.dividendDirectionMin !== null &&
-        stock.配当方向性 !== null &&
-        stock.配当方向性 !== undefined &&
-        typeof stock.配当方向性 === "number" &&
-        stock.配当方向性 < filters.dividendDirectionMin / 100
-      ) {
-        return false;
-      }
-      if (
-        filters.dividendDirectionMax !== null &&
-        stock.配当方向性 !== null &&
-        stock.配当方向性 !== undefined &&
-        typeof stock.配当方向性 === "number" &&
-        stock.配当方向性 > filters.dividendDirectionMax / 100
-      ) {
-        return false;
-      }
-
-      // 配当利回りフィルター（%）（データがnull/undefinedの場合は含める）
-      if (
-        filters.dividendYieldMin !== null &&
-        stock.配当利回り !== null &&
-        stock.配当利回り !== undefined &&
-        typeof stock.配当利回り === "number" &&
-        stock.配当利回り < filters.dividendYieldMin / 100
-      ) {
-        return false;
-      }
-      if (
-        filters.dividendYieldMax !== null &&
-        stock.配当利回り !== null &&
-        stock.配当利回り !== undefined &&
-        typeof stock.配当利回り === "number" &&
-        stock.配当利回り > filters.dividendYieldMax / 100
-      ) {
-        return false;
-      }
-
-      // EPS(過去12ヶ月)フィルター（データがnull/undefinedの場合は含める）
-      if (
-        filters.trailingEpsMin !== null &&
-        stock["EPS(過去12ヶ月)"] !== null &&
-        stock["EPS(過去12ヶ月)"] !== undefined &&
-        typeof stock["EPS(過去12ヶ月)"] === "number" &&
-        stock["EPS(過去12ヶ月)"] < filters.trailingEpsMin
-      ) {
-        return false;
-      }
-      if (
-        filters.trailingEpsMax !== null &&
-        stock["EPS(過去12ヶ月)"] !== null &&
-        stock["EPS(過去12ヶ月)"] !== undefined &&
-        typeof stock["EPS(過去12ヶ月)"] === "number" &&
-        stock["EPS(過去12ヶ月)"] > filters.trailingEpsMax
-      ) {
-        return false;
-      }
-
-      // EPS(予想)フィルター（データがnull/undefinedの場合は含める）
-      if (
-        filters.forwardEpsMin !== null &&
-        stock["EPS(予想)"] !== null &&
-        stock["EPS(予想)"] !== undefined &&
-        typeof stock["EPS(予想)"] === "number" &&
-        stock["EPS(予想)"] < filters.forwardEpsMin
-      ) {
-        return false;
-      }
-      if (
-        filters.forwardEpsMax !== null &&
-        stock["EPS(予想)"] !== null &&
-        stock["EPS(予想)"] !== undefined &&
-        typeof stock["EPS(予想)"] === "number" &&
-        stock["EPS(予想)"] > filters.forwardEpsMax
-      ) {
-        return false;
-      }
-
-      // EPS(前年度)フィルター（データがnull/undefinedの場合は含める）
-      if (
-        filters.previousYearEpsMin !== null &&
-        stock["EPS(前年度)"] !== null &&
-        stock["EPS(前年度)"] !== undefined &&
-        typeof stock["EPS(前年度)"] === "number" &&
-        stock["EPS(前年度)"] < filters.previousYearEpsMin
-      ) {
-        return false;
-      }
-      if (
-        filters.previousYearEpsMax !== null &&
-        stock["EPS(前年度)"] !== null &&
-        stock["EPS(前年度)"] !== undefined &&
-        typeof stock["EPS(前年度)"] === "number" &&
-        stock["EPS(前年度)"] > filters.previousYearEpsMax
-      ) {
-        return false;
-      }
-
-      // 負債フィルター（データがnull/undefinedの場合は含める）
-      if (
-        filters.totalLiabilitiesMin !== null &&
-        stock.負債 !== null &&
-        stock.負債 !== undefined &&
-        typeof stock.負債 === "number" &&
-        stock.負債 < filters.totalLiabilitiesMin * 1000000
-      ) {
-        return false;
-      }
-      if (
-        filters.totalLiabilitiesMax !== null &&
-        stock.負債 !== null &&
-        stock.負債 !== undefined &&
-        typeof stock.負債 === "number" &&
-        stock.負債 > filters.totalLiabilitiesMax * 1000000
-      ) {
-        return false;
-      }
-
-      // 流動負債フィルター（データがnull/undefinedの場合は含める）
-      if (
-        filters.currentLiabilitiesMin !== null &&
-        stock.流動負債 !== null &&
-        stock.流動負債 !== undefined &&
-        typeof stock.流動負債 === "number" &&
-        stock.流動負債 < filters.currentLiabilitiesMin * 1000000
-      ) {
-        return false;
-      }
-      if (
-        filters.currentLiabilitiesMax !== null &&
-        stock.流動負債 !== null &&
-        stock.流動負債 !== undefined &&
-        typeof stock.流動負債 === "number" &&
-        stock.流動負債 > filters.currentLiabilitiesMax * 1000000
-      ) {
-        return false;
-      }
-
-      // 流動資産フィルター（データがnull/undefinedの場合は含める）
-      if (
-        filters.currentAssetsMin !== null &&
-        stock.流動資産 !== null &&
-        stock.流動資産 !== undefined &&
-        typeof stock.流動資産 === "number" &&
-        stock.流動資産 < filters.currentAssetsMin * 1000000
-      ) {
-        return false;
-      }
-      if (
-        filters.currentAssetsMax !== null &&
-        stock.流動資産 !== null &&
-        stock.流動資産 !== undefined &&
-        typeof stock.流動資産 === "number" &&
-        stock.流動資産 > filters.currentAssetsMax * 1000000
-      ) {
-        return false;
-      }
-
-      // 総負債フィルター（データがnull/undefinedの場合は含める）
-      if (
-        filters.totalDebtMin !== null &&
-        stock.総負債 !== null &&
-        stock.総負債 !== undefined &&
-        typeof stock.総負債 === "number" &&
-        stock.総負債 < filters.totalDebtMin * 1000000
-      ) {
-        return false;
-      }
-      if (
-        filters.totalDebtMax !== null &&
-        stock.総負債 !== null &&
-        stock.総負債 !== undefined &&
-        typeof stock.総負債 === "number" &&
-        stock.総負債 > filters.totalDebtMax * 1000000
-      ) {
-        return false;
-      }
-
-      // 現金及び現金同等物フィルター（データがnull/undefinedの場合は含める）
-      if (
-        filters.cashMin !== null &&
-        stock["現金及び現金同等物"] !== null &&
-        stock["現金及び現金同等物"] !== undefined &&
-        typeof stock["現金及び現金同等物"] === "number" &&
-        stock["現金及び現金同等物"] < filters.cashMin * 1000000
-      ) {
-        return false;
-      }
-      if (
-        filters.cashMax !== null &&
-        stock["現金及び現金同等物"] !== null &&
-        stock["現金及び現金同等物"] !== undefined &&
-        typeof stock["現金及び現金同等物"] === "number" &&
-        stock["現金及び現金同等物"] > filters.cashMax * 1000000
-      ) {
-        return false;
-      }
-
-      // 投資有価証券フィルター（データがnull/undefinedの場合は含める）
-      if (
-        filters.investmentsMin !== null &&
-        stock.投資有価証券 !== null &&
-        stock.投資有価証券 !== undefined &&
-        typeof stock.投資有価証券 === "number" &&
-        stock.投資有価証券 < filters.investmentsMin * 1000000
-      ) {
-        return false;
-      }
-      if (
-        filters.investmentsMax !== null &&
-        stock.投資有価証券 !== null &&
-        stock.投資有価証券 !== undefined &&
-        typeof stock.投資有価証券 === "number" &&
-        stock.投資有価証券 > filters.investmentsMax * 1000000
-      ) {
-        return false;
-      }
-
-      // ネットキャッシュフィルター（キーは ネットキャッシュ または ネットキャッシュ（流動資産-負債））
-      const netCashValue = stock.ネットキャッシュ ?? stock["ネットキャッシュ（流動資産-負債）"];
-      if (
-        filters.netCashMin !== null &&
-        netCashValue !== null &&
-        netCashValue !== undefined &&
-        typeof netCashValue === "number" &&
-        netCashValue < filters.netCashMin * 1000000
-      ) {
-        return false;
-      }
-      if (
-        filters.netCashMax !== null &&
-        netCashValue !== null &&
-        netCashValue !== undefined &&
-        typeof netCashValue === "number" &&
-        netCashValue > filters.netCashMax * 1000000
-      ) {
-        return false;
-      }
-
-      // ネットキャッシュ比率フィルター（%）（データがnull/undefinedの場合は含める）
-      if (
-        filters.netCashRatioMin !== null &&
-        stock.ネットキャッシュ比率 !== null &&
-        stock.ネットキャッシュ比率 !== undefined &&
-        typeof stock.ネットキャッシュ比率 === "number" &&
-        stock.ネットキャッシュ比率 < filters.netCashRatioMin / 100
-      ) {
-        return false;
-      }
-      if (
-        filters.netCashRatioMax !== null &&
-        stock.ネットキャッシュ比率 !== null &&
-        stock.ネットキャッシュ比率 !== undefined &&
-        typeof stock.ネットキャッシュ比率 === "number" &&
-        stock.ネットキャッシュ比率 > filters.netCashRatioMax / 100
-      ) {
-        return false;
-      }
-
-      return true;
-    });
-
-    // ソート処理
-    if (sortConfig) {
-      filtered.sort((a, b) => {
-        const aValue = a[sortConfig.key];
-        const bValue = b[sortConfig.key];
-
-        // null値の処理
-        if (aValue === null && bValue === null) return 0;
-        if (aValue === null) return 1;
-        if (bValue === null) return -1;
-
-        let result = 0;
-        if (typeof aValue === "string" && typeof bValue === "string") {
-          result = aValue.localeCompare(bValue, "ja-JP");
-        } else if (typeof aValue === "number" && typeof bValue === "number") {
-          result = aValue - bValue;
-        }
-
-        return sortConfig.direction === "desc" ? -result : result;
+  const setScreenerAndSync = useCallback(
+    (updater: ScreenerState | ((prev: ScreenerState) => ScreenerState)) => {
+      setScreener((prev) => {
+        const next = typeof updater === "function" ? updater(prev) : updater;
+        syncUrl(next);
+        return next;
       });
+    },
+    [syncUrl]
+  );
+
+  const updateScreenerField = useCallback(
+    <K extends ScreenerCategoricalKey>(key: K, value: ScreenerState[K]) => {
+      setScreenerAndSync((prev) => ({ ...prev, [key]: value }));
+    },
+    [setScreenerAndSync]
+  );
+
+  /** Sidebar 互換: カテゴリ・テキスト検索 */
+  const updateFilter = (
+    key: ScreenerCategoricalKey | "companyName" | "stockCode",
+    value: string | number | string[] | boolean | null
+  ) => {
+    if (key === "excludeMissing" && typeof value === "boolean") {
+      updateScreenerField("excludeMissing", value);
+      return;
     }
-
-    return filtered;
-  }, [data, filters, sortConfig]);
-
-  const updateFilter = (key: keyof SearchFilters, value: string | number | string[] | null) => {
-    const newFilters = {
-      ...filters,
-      [key]: value,
-    };
-    setFilters(newFilters);
-    updateUrlWithFilters(newFilters);
+    if (key === "companyName" || key === "stockCode") {
+      setScreenerAndSync((prev) => ({
+        ...prev,
+        [key]: typeof value === "string" ? value : "",
+      }));
+      return;
+    }
+    if (Array.isArray(value) || value === null) {
+      setScreenerAndSync((prev) => ({
+        ...prev,
+        [key]: (value ?? []) as string[] & ("JP" | "US")[],
+      }));
+    }
   };
 
   const clearFilters = () => {
-    setFilters(initialFilters);
+    const next = initialScreenerState();
+    setScreener(next);
     navigate(location.pathname, { replace: true });
   };
 
-  const applyPreset = (preset: Partial<SearchFilters>) => {
-    const newFilters: SearchFilters = {
-      ...initialFilters,
-      ...preset,
-      // テキスト検索・業種・市場選択は引き継ぐ
-      companyName: filters.companyName,
-      stockCode: filters.stockCode,
-      industries: filters.industries,
-      marketType: filters.marketType,
-      market: filters.market,
-      prefecture: filters.prefecture,
+  const addCondition = (partial?: Partial<Omit<ScreenerCondition, "id">>) => {
+    const firstField = screenableFields[0]?.field ?? "ROE";
+    const condition: ScreenerCondition = {
+      id: crypto.randomUUID(),
+      field: partial?.field ?? firstField,
+      operator: partial?.operator ?? "gte",
+      value: partial?.value ?? 0,
     };
-    setFilters(newFilters);
-    updateUrlWithFilters(newFilters);
+    setScreenerAndSync((prev) => ({
+      ...prev,
+      conditions: [...prev.conditions, condition],
+    }));
+    return condition.id;
+  };
+
+  const updateCondition = (id: string, patch: Partial<Omit<ScreenerCondition, "id">>) => {
+    setScreenerAndSync((prev) => ({
+      ...prev,
+      conditions: prev.conditions.map((c) => (c.id === id ? { ...c, ...patch } : c)),
+    }));
+  };
+
+  const removeCondition = (id: string) => {
+    setScreenerAndSync((prev) => ({
+      ...prev,
+      conditions: prev.conditions.filter((c) => c.id !== id),
+    }));
+  };
+
+  const clearConditions = () => {
+    setScreenerAndSync((prev) => ({ ...prev, conditions: [] }));
+  };
+
+  const applyPresetConditions = (conditions: ScreenerCondition[]) => {
+    setScreenerAndSync((prev) => ({
+      ...initialScreenerState(),
+      companyName: prev.companyName,
+      stockCode: prev.stockCode,
+      industries: prev.industries,
+      marketType: prev.marketType,
+      market: prev.market,
+      prefecture: prev.prefecture,
+      conditions: conditions.map((c) => ({ ...c, id: crypto.randomUUID() })),
+    }));
+  };
+
+  /** @deprecated use applyPresetConditions */
+  const applyPreset = (legacy: Parameters<typeof searchFiltersToScreenerState>[0]) => {
+    const migrated = searchFiltersToScreenerState(legacy);
+    applyPresetConditions(migrated.conditions);
   };
 
   const MAX_CUSTOM_PRESETS = 30;
   const MAX_CUSTOM_PRESET_LABEL = 40;
 
   const applyCustomFilterPreset = (preset: SavedFilterPreset) => {
-    const merged: SearchFilters = {
-      ...initialFilters,
-      ...structuredClone(preset.filters),
-    };
-    setFilters(merged);
-    updateUrlWithFilters(merged);
+    const conditions =
+      preset.conditions ??
+      (preset.filters ? searchFiltersToScreenerState(preset.filters).conditions : []);
+    const base = preset.screener ?? {};
+    setScreenerAndSync({
+      ...initialScreenerState(),
+      ...base,
+      conditions: conditions.map((c) => ({ ...c, id: crypto.randomUUID() })),
+      sort: null,
+    });
   };
 
   const saveCustomFilterPreset = (label: string): string | null => {
@@ -762,8 +179,16 @@ export const useFilters = (data: StockData[]) => {
       return `マイプリセットは最大${MAX_CUSTOM_PRESETS}件までです`;
     }
     const id = `user-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
-    const snapshot = structuredClone(filters) as SearchFilters;
-    setCustomPresets((prev) => [...prev, { id, label: trimmed, filters: snapshot }]);
+    const { conditions, sort, ...screenerMeta } = screener;
+    setCustomPresets((prev) => [
+      ...prev,
+      {
+        id,
+        label: trimmed,
+        conditions: structuredClone(conditions),
+        screener: structuredClone(screenerMeta),
+      },
+    ]);
     return null;
   };
 
@@ -771,15 +196,11 @@ export const useFilters = (data: StockData[]) => {
     setCustomPresets((prev) => prev.filter((p) => p.id !== id));
   };
 
-  const shareFilters = () => {
-    const shareUrl = generateShareUrl(filters);
-    return shareUrl;
-  };
+  const shareFilters = () => generateShareUrl(screener);
 
   const copyShareUrl = async () => {
-    const shareUrl = shareFilters();
     try {
-      await navigator.clipboard.writeText(shareUrl);
+      await navigator.clipboard.writeText(shareFilters());
       return true;
     } catch (error) {
       console.error("Failed to copy URL:", error);
@@ -788,20 +209,29 @@ export const useFilters = (data: StockData[]) => {
   };
 
   const handleSort = (key: keyof StockData) => {
-    setSortConfig((current) => {
+    setScreenerAndSync((prev) => {
+      const current = prev.sort;
+      let nextSort: SortConfig | null;
       if (!current || current.key !== key) {
-        return { key, direction: "asc" };
+        nextSort = { key, direction: "asc" };
+      } else if (current.direction === "asc") {
+        nextSort = { key, direction: "desc" };
+      } else {
+        nextSort = null;
       }
-      if (current.direction === "asc") {
-        return { key, direction: "desc" };
-      }
-      return null; // ソート解除
+      return { ...prev, sort: nextSort };
     });
   };
 
-  // ユニークな業種一覧を取得
+  const setSortFromDropdown = (key: string | "", direction: "asc" | "desc") => {
+    setScreenerAndSync((prev) => ({
+      ...prev,
+      sort: key ? ({ key, direction } as SortConfig) : null,
+    }));
+  };
+
   const availableIndustries = useMemo(() => {
-    const industries = data
+    return data
       .map((stock) => stock.業種)
       .filter(
         (industry): industry is string =>
@@ -809,42 +239,31 @@ export const useFilters = (data: StockData[]) => {
       )
       .filter((industry, index, arr) => arr.indexOf(industry) === index)
       .sort();
-    return industries;
   }, [data]);
 
-  // ユニークな市場一覧を取得（選択された市場タイプに応じてフィルタリング）
   const availableMarkets = useMemo(() => {
-    let filteredData = data;
-
-    // 市場タイプフィルターが適用されている場合、該当する市場タイプのデータのみを対象にする
-    if (filters.marketType && filters.marketType.length > 0) {
-      filteredData = data.filter((stock) => {
+    let subset = data;
+    if (screener.marketType.length > 0) {
+      subset = data.filter((stock) => {
         const stockMarketType =
           stock.市場タイプ || detectMarketTypeFromTicker(stock.銘柄コード || stock.コード || "");
-        return filters.marketType!.includes(stockMarketType as "JP" | "US");
+        return screener.marketType.includes(stockMarketType as "JP" | "US");
       });
     }
-
-    const markets = filteredData
+    return subset
       .map((stock) => stock.優先市場)
-      .filter(
-        (market): market is string => market !== undefined && market !== null && market !== ""
-      )
+      .filter((market): market is string => market !== undefined && market !== null && market !== "")
       .filter((market, index, arr) => arr.indexOf(market) === index)
       .sort();
-    return markets;
-  }, [data, filters.marketType]);
+  }, [data, screener.marketType]);
 
-  // ユニークな都道府県一覧を取得（日本株のみ）
   const availablePrefectures = useMemo(() => {
-    // 日本株のみを対象にする
     const jpStocks = data.filter((stock) => {
       const stockMarketType =
         stock.市場タイプ || detectMarketTypeFromTicker(stock.銘柄コード || stock.コード || "");
       return stockMarketType === "JP";
     });
-
-    const prefectures = jpStocks
+    return jpStocks
       .map((stock) => stock.都道府県)
       .filter(
         (prefecture): prefecture is string =>
@@ -852,24 +271,32 @@ export const useFilters = (data: StockData[]) => {
       )
       .filter((prefecture, index, arr) => arr.indexOf(prefecture) === index)
       .sort();
-    return prefectures;
   }, [data]);
 
   return {
-    filters,
+    screener,
+    filters: screener,
     filteredData,
     sortConfig,
+    screenableFields,
     availableIndustries,
     availableMarkets,
     availablePrefectures,
     updateFilter,
+    updateScreenerField,
     clearFilters,
     applyPreset,
+    applyPresetConditions,
     customPresets,
     saveCustomFilterPreset,
     removeCustomFilterPreset,
     applyCustomFilterPreset,
+    addCondition,
+    updateCondition,
+    removeCondition,
+    clearConditions,
     handleSort,
+    setSortFromDropdown,
     shareFilters,
     copyShareUrl,
   };

--- a/stock_search/src/pages/DataPage.tsx
+++ b/stock_search/src/pages/DataPage.tsx
@@ -22,6 +22,8 @@ import { Pagination } from "../components/Pagination";
 import { ColumnSelector, type ColumnConfig } from "../components/ColumnSelector";
 import { getDefaultColumns } from "../utils/columnConfig";
 import { DownloadButton } from "../components/DownloadButton";
+import { ScreenerBar } from "../components/ScreenerBar";
+import type { FilterPreset } from "../constants/presets";
 import type { PaginationConfig } from "../types/stock";
 import { PAGINATION } from "../constants/ui";
 import {
@@ -210,20 +212,29 @@ export const DataPage = () => {
 
   const { data, loading, error, reload } = useCSVParser(selectedFile);
   const {
+    screener,
     filters,
     filteredData,
     sortConfig,
+    screenableFields,
     availableIndustries,
     availableMarkets,
     availablePrefectures,
     updateFilter,
     clearFilters,
-    applyPreset,
+    applyPresetConditions,
     customPresets,
     saveCustomFilterPreset,
     removeCustomFilterPreset,
     applyCustomFilterPreset,
+    addCondition,
+    updateCondition,
+    removeCondition,
+    clearConditions,
     handleSort,
+    setSortFromDropdown,
+    copyShareUrl,
+    updateScreenerField,
   } = useFilters(data);
   const { favoriteCodesSet, toggle: onToggleFavorite } = useFavorites();
 
@@ -298,7 +309,7 @@ export const DataPage = () => {
     filters,
     onFilterChange: updateFilter,
     onClearFilters: clearFilters,
-    onApplyPreset: applyPreset,
+    onApplyPreset: (preset: FilterPreset) => applyPresetConditions(preset.conditions),
     customPresets,
     onSaveCustomPreset: saveCustomFilterPreset,
     onApplyCustomPreset: applyCustomFilterPreset,
@@ -516,6 +527,22 @@ export const DataPage = () => {
 
           {selectedFile && !loading && !error && data.length > 0 && (
             <>
+              <ScreenerBar
+                totalCount={data.length}
+                filteredCount={filteredData.length}
+                screener={screener}
+                screenableFields={screenableFields}
+                sortableKeys={screenableFields.map((f) => f.field)}
+                onAddCondition={() => addCondition()}
+                onUpdateCondition={updateCondition}
+                onRemoveCondition={removeCondition}
+                onClearConditions={clearConditions}
+                onClearAll={clearFilters}
+                onExcludeMissingChange={(v) => updateScreenerField("excludeMissing", v)}
+                onSetSort={setSortFromDropdown}
+                onCopyShareUrl={copyShareUrl}
+              />
+
               {/* タブ: すべて / お気に入りのみ ＋ Main toolbar */}
               <div className="px-3 md:px-6 py-2 border-b border-[var(--border)] flex flex-wrap items-center justify-between gap-2 md:gap-3 flex-shrink-0">
                 <div className="flex items-center gap-2 md:gap-4 min-w-0 flex-1">

--- a/stock_search/src/types/stock.ts
+++ b/stock_search/src/types/stock.ts
@@ -102,11 +102,46 @@ export interface SearchFilters {
   netCashRatioMax: number | null;
 }
 
+export type ScreenerOperator = "gte" | "lte" | "between" | "eq";
+
+export interface ScreenerCondition {
+  id: string;
+  field: string;
+  operator: ScreenerOperator;
+  value: number | [number, number];
+}
+
+export interface ScreenerState {
+  conditions: ScreenerCondition[];
+  companyName: string;
+  stockCode: string;
+  industries: string[];
+  market: string[];
+  prefecture: string[];
+  marketType: ("JP" | "US")[];
+  excludeMissing: boolean;
+  sort: SortConfig | null;
+}
+
+export type ScreenerCategoricalKey =
+  | "companyName"
+  | "stockCode"
+  | "industries"
+  | "market"
+  | "prefecture"
+  | "marketType"
+  | "excludeMissing";
+
 /** ユーザーが保存したスクリーニング条件（localStorage に永続化） */
 export interface SavedFilterPreset {
   id: string;
   label: string;
-  filters: SearchFilters;
+  /** v2: 動的条件 */
+  conditions?: ScreenerCondition[];
+  /** v1 互換（読み込み時に conditions へ変換） */
+  filters?: SearchFilters;
+  /** v2 カテゴリ・検索（filters 非使用時） */
+  screener?: Omit<ScreenerState, "conditions" | "sort">;
 }
 
 export interface SortConfig {

--- a/stock_search/src/utils/customFilterPresetsStorage.ts
+++ b/stock_search/src/utils/customFilterPresetsStorage.ts
@@ -1,4 +1,5 @@
-import type { SavedFilterPreset, SearchFilters } from "../types/stock";
+import type { SavedFilterPreset, ScreenerCondition, SearchFilters } from "../types/stock";
+import { searchFiltersToConditions } from "./searchFiltersMigration";
 
 const STORAGE_KEY = "yfinance-jp-screener-custom-filter-presets";
 
@@ -8,6 +9,17 @@ function isRecord(v: unknown): v is Record<string, unknown> {
 
 function looksLikeSearchFilters(obj: Record<string, unknown>): boolean {
   return typeof obj.companyName === "string" && Array.isArray(obj.industries);
+}
+
+function isScreenerConditionArray(arr: unknown): arr is ScreenerCondition[] {
+  if (!Array.isArray(arr) || arr.length === 0) return Array.isArray(arr);
+  return arr.every(
+    (c) =>
+      isRecord(c) &&
+      typeof c.id === "string" &&
+      typeof c.field === "string" &&
+      typeof c.operator === "string"
+  );
 }
 
 export function loadCustomFilterPresets(): SavedFilterPreset[] {
@@ -21,10 +33,37 @@ export function loadCustomFilterPresets(): SavedFilterPreset[] {
       if (!isRecord(item)) continue;
       const id = item.id;
       const label = item.label;
+      if (typeof id !== "string" || typeof label !== "string") continue;
+
+      if (isScreenerConditionArray(item.conditions)) {
+        out.push({
+          id,
+          label,
+          conditions: item.conditions as ScreenerCondition[],
+          screener: isRecord(item.screener)
+            ? (item.screener as SavedFilterPreset["screener"])
+            : undefined,
+        });
+        continue;
+      }
+
       const filters = item.filters;
-      if (typeof id !== "string" || typeof label !== "string" || !isRecord(filters)) continue;
-      if (!looksLikeSearchFilters(filters)) continue;
-      out.push({ id, label, filters: filters as unknown as SearchFilters });
+      if (isRecord(filters) && looksLikeSearchFilters(filters)) {
+        out.push({
+          id,
+          label,
+          conditions: searchFiltersToConditions(filters as unknown as SearchFilters),
+          screener: {
+            companyName: (filters.companyName as string) ?? "",
+            stockCode: (filters.stockCode as string) ?? "",
+            industries: (filters.industries as string[]) ?? [],
+            market: (filters.market as string[]) ?? [],
+            prefecture: (filters.prefecture as string[]) ?? [],
+            marketType: (filters.marketType as ("JP" | "US")[]) ?? ["JP", "US"],
+            excludeMissing: false,
+          },
+        });
+      }
     }
     return out;
   } catch {

--- a/stock_search/src/utils/screenerEngine.test.ts
+++ b/stock_search/src/utils/screenerEngine.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import type { StockData, ScreenerState } from "../types/stock";
+import { evaluateRow, filterStocks } from "./screenerEngine";
+import { initialScreenerState } from "./searchFiltersMigration";
+
+const baseStock: StockData = {
+  会社名: "テスト株式会社",
+  銘柄コード: "7203",
+  業種: "輸送用機器",
+  優先市場: "プライム（内国株式）",
+  市場タイプ: "JP",
+  PBR: 0.8,
+  ROE: 0.15,
+  時価総額: 50_000_000_000_000,
+  ネットキャッシュ: 1_000_000_000_000,
+  "ネットキャッシュ（流動資産-負債）": 1_000_000_000_000,
+};
+
+function stateWith(overrides: Partial<ScreenerState>): ScreenerState {
+  return { ...initialScreenerState(), ...overrides };
+}
+
+describe("screenerEngine", () => {
+  it("converts percent UI values for ROE", () => {
+    const state = stateWith({
+      conditions: [{ id: "1", field: "ROE", operator: "gte", value: 10 }],
+    });
+    expect(evaluateRow({ ...baseStock, ROE: 0.08 }, state)).toBe(false);
+    expect(evaluateRow({ ...baseStock, ROE: 0.12 }, state)).toBe(true);
+  });
+
+  it("converts market cap from million yen UI", () => {
+    const state = stateWith({
+      conditions: [{ id: "1", field: "時価総額", operator: "gte", value: 100 }],
+    });
+    expect(evaluateRow(baseStock, state)).toBe(true);
+    expect(evaluateRow({ ...baseStock, 時価総額: 50_000_000 }, state)).toBe(false);
+  });
+
+  it("excludes rows with missing values when excludeMissing is true", () => {
+    const state = stateWith({
+      excludeMissing: true,
+      conditions: [{ id: "1", field: "ROE", operator: "gte", value: 5 }],
+    });
+    expect(evaluateRow({ ...baseStock, ROE: null }, state)).toBe(false);
+    expect(evaluateRow({ ...baseStock, ROE: 0.1 }, state)).toBe(true);
+  });
+
+  it("passes rows with missing values when excludeMissing is false", () => {
+    const state = stateWith({
+      excludeMissing: false,
+      conditions: [{ id: "1", field: "ROE", operator: "gte", value: 99 }],
+    });
+    expect(evaluateRow({ ...baseStock, ROE: null }, state)).toBe(true);
+  });
+
+  it("AND-combines multiple conditions", () => {
+    const state = stateWith({
+      conditions: [
+        { id: "1", field: "PBR", operator: "lte", value: 1 },
+        { id: "2", field: "ROE", operator: "gte", value: 15 },
+      ],
+    });
+    expect(evaluateRow(baseStock, state)).toBe(true);
+    expect(evaluateRow({ ...baseStock, PBR: 2 }, state)).toBe(false);
+  });
+
+  it("resolves net cash field aliases", () => {
+    const state = stateWith({
+      conditions: [{ id: "1", field: "ネットキャッシュ", operator: "gte", value: 500 }],
+    });
+    const stock = {
+      ...baseStock,
+      ネットキャッシュ: undefined,
+      "ネットキャッシュ（流動資産-負債）": 600_000_000,
+    };
+    expect(evaluateRow(stock, state)).toBe(true);
+  });
+
+  it("filters and sorts dataset", () => {
+    const rows: StockData[] = [
+      { ...baseStock, 銘柄コード: "1", ROE: 0.2 },
+      { ...baseStock, 銘柄コード: "2", ROE: 0.05 },
+    ];
+    const state = stateWith({
+      conditions: [{ id: "1", field: "ROE", operator: "gte", value: 10 }],
+      sort: { key: "ROE", direction: "desc" },
+    });
+    const result = filterStocks(rows, state);
+    expect(result).toHaveLength(1);
+    expect(result[0].銘柄コード).toBe("1");
+  });
+});

--- a/stock_search/src/utils/screenerEngine.ts
+++ b/stock_search/src/utils/screenerEngine.ts
@@ -1,0 +1,130 @@
+import type { StockData, ScreenerCondition, ScreenerState, SortConfig } from "../types/stock";
+import {
+  getFieldMeta,
+  resolveStockFieldValue,
+  uiValueToStored,
+  type ScreenerFieldKind,
+} from "./screenerFieldRegistry";
+
+export function detectMarketTypeFromTicker(ticker: string): "JP" | "US" {
+  if (!ticker) return "JP";
+  const tickerStr = String(ticker).trim();
+  if (tickerStr.endsWith(".T")) return "JP";
+  if (/^\d{4}$/.test(tickerStr)) return "JP";
+  if (/^[A-Z]{1,5}$/i.test(tickerStr)) return "US";
+  return "JP";
+}
+
+function getNumericValue(
+  stock: StockData,
+  field: string
+): number | null {
+  const raw = resolveStockFieldValue(stock, field);
+  if (raw === null || raw === undefined || raw === "") return null;
+  if (typeof raw === "number") return Number.isFinite(raw) ? raw : null;
+  const parsed = Number(String(raw).replace(/,/g, ""));
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function compareCondition(
+  stock: StockData,
+  condition: ScreenerCondition,
+  excludeMissing: boolean
+): boolean {
+  const meta = getFieldMeta(condition.field);
+  const kind: ScreenerFieldKind = meta?.kind ?? "number";
+  const value = getNumericValue(stock, condition.field);
+
+  if (value === null) {
+    return !excludeMissing;
+  }
+
+  const toStored = (ui: number) => uiValueToStored(kind, ui);
+
+  switch (condition.operator) {
+    case "gte":
+      return value >= toStored(condition.value as number);
+    case "lte":
+      return value <= toStored(condition.value as number);
+    case "eq": {
+      const target = toStored(condition.value as number);
+      const epsilon = kind === "ratio" ? 0.0001 : 0.000001;
+      return Math.abs(value - target) <= epsilon;
+    }
+    case "between": {
+      const [minUi, maxUi] = condition.value as [number, number];
+      const min = toStored(minUi);
+      const max = toStored(maxUi);
+      return value >= min && value <= max;
+    }
+    default:
+      return true;
+  }
+}
+
+export function evaluateRow(stock: StockData, state: ScreenerState): boolean {
+  if (state.companyName) {
+    const companyNameStr = (stock.会社名 || "").toLowerCase();
+    if (!companyNameStr.includes(state.companyName.toLowerCase())) return false;
+  }
+
+  if (state.stockCode) {
+    const stockCode = stock.銘柄コード || stock.コード || "";
+    if (!stockCode.toString().includes(state.stockCode)) return false;
+  }
+
+  if (state.industries.length > 0 && !state.industries.includes(stock.業種 || "")) {
+    return false;
+  }
+
+  if (state.marketType && state.marketType.length > 0) {
+    const stockMarketType =
+      stock.市場タイプ || detectMarketTypeFromTicker(stock.銘柄コード || stock.コード || "");
+    if (!state.marketType.includes(stockMarketType as "JP" | "US")) return false;
+  }
+
+  if (state.market.length > 0 && !state.market.includes(stock.優先市場 || "")) {
+    return false;
+  }
+
+  if (state.prefecture.length > 0) {
+    const stockMarketType =
+      stock.市場タイプ || detectMarketTypeFromTicker(stock.銘柄コード || stock.コード || "");
+    if (stockMarketType === "JP" && !state.prefecture.includes(stock.都道府県 || "")) {
+      return false;
+    }
+  }
+
+  for (const condition of state.conditions) {
+    if (!compareCondition(stock, condition, state.excludeMissing)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function sortRows(data: StockData[], sort: SortConfig | null): StockData[] {
+  if (!sort) return data;
+  const sorted = [...data];
+  sorted.sort((a, b) => {
+    const aValue = a[sort.key];
+    const bValue = b[sort.key];
+    if (aValue === null && bValue === null) return 0;
+    if (aValue === null || aValue === undefined) return 1;
+    if (bValue === null || bValue === undefined) return -1;
+    let result = 0;
+    if (typeof aValue === "string" && typeof bValue === "string") {
+      result = aValue.localeCompare(bValue, "ja-JP");
+    } else if (typeof aValue === "number" && typeof bValue === "number") {
+      result = aValue - bValue;
+    }
+    return sort.direction === "desc" ? -result : result;
+  });
+  return sorted;
+}
+
+export function filterStocks(data: StockData[], state: ScreenerState): StockData[] {
+  const filtered = data.filter((stock) => evaluateRow(stock, state));
+  return sortRows(filtered, state.sort);
+}

--- a/stock_search/src/utils/screenerFieldRegistry.ts
+++ b/stock_search/src/utils/screenerFieldRegistry.ts
@@ -1,0 +1,217 @@
+import { FILTER_TOOLTIPS } from "../constants/tooltips";
+import type { ScreenerOperator } from "../types/stock";
+
+export type ScreenerFieldKind =
+  | "percent"
+  | "currency_million"
+  | "ratio"
+  | "number"
+  | "string";
+
+export type ScreenerFieldCategory =
+  | "basic"
+  | "valuation"
+  | "performance"
+  | "balance"
+  | "cash";
+
+export interface ScreenerFieldMeta {
+  field: string;
+  label: string;
+  kind: ScreenerFieldKind;
+  category: ScreenerFieldCategory;
+  unit?: string;
+  aliases?: string[];
+  tooltip?: string;
+}
+
+const NUMERIC_OPERATORS = ["gte", "lte", "between", "eq"] as const;
+
+export function getAllowedOperators(kind: ScreenerFieldKind): readonly ScreenerOperator[] {
+  if (kind === "string") return [];
+  return NUMERIC_OPERATORS;
+}
+
+const BUILTIN_FIELDS: ScreenerFieldMeta[] = [
+  { field: "時価総額", label: "時価総額", kind: "currency_million", category: "valuation", unit: "百万円", tooltip: FILTER_TOOLTIPS["時価総額"] },
+  { field: "PBR", label: "PBR", kind: "ratio", category: "valuation", tooltip: FILTER_TOOLTIPS.PBR },
+  { field: "ROE", label: "ROE", kind: "percent", category: "valuation", unit: "%", tooltip: FILTER_TOOLTIPS.ROE },
+  { field: "自己資本比率", label: "自己資本比率", kind: "percent", category: "valuation", unit: "%", tooltip: FILTER_TOOLTIPS["自己資本比率"] },
+  { field: "PER(会予)", label: "PER(会予)", kind: "ratio", category: "valuation", tooltip: FILTER_TOOLTIPS["PER(会予)"] },
+  { field: "PER(過去12ヶ月)", label: "PER(過去12ヶ月)", kind: "ratio", category: "valuation", tooltip: FILTER_TOOLTIPS["PER(過去12ヶ月)"] },
+  { field: "PER(前年度)", label: "PER(前年度)", kind: "ratio", category: "valuation", tooltip: FILTER_TOOLTIPS["PER(前年度)"] },
+  { field: "配当方向性", label: "配当性向", kind: "percent", category: "valuation", unit: "%", tooltip: FILTER_TOOLTIPS["配当性向"] },
+  { field: "配当利回り", label: "配当利回り", kind: "percent", category: "valuation", unit: "%", tooltip: FILTER_TOOLTIPS["配当利回り"] },
+  { field: "EPS(過去12ヶ月)", label: "EPS(過去12ヶ月)", kind: "number", category: "valuation", tooltip: FILTER_TOOLTIPS["EPS(過去12ヶ月)"] },
+  { field: "EPS(予想)", label: "EPS(予想)", kind: "number", category: "valuation", tooltip: FILTER_TOOLTIPS["EPS(予想)"] },
+  { field: "EPS(前年度)", label: "EPS(前年度)", kind: "number", category: "valuation", tooltip: FILTER_TOOLTIPS["EPS(前年度)"] },
+  { field: "売上高", label: "売上高", kind: "currency_million", category: "performance", unit: "百万円", tooltip: FILTER_TOOLTIPS["売上高"] },
+  { field: "営業利益", label: "営業利益", kind: "currency_million", category: "performance", unit: "百万円", tooltip: FILTER_TOOLTIPS["営業利益"] },
+  { field: "営業利益率", label: "営業利益率", kind: "percent", category: "performance", unit: "%", tooltip: FILTER_TOOLTIPS["営業利益率"] },
+  { field: "当期純利益", label: "当期純利益", kind: "currency_million", category: "performance", unit: "百万円", tooltip: FILTER_TOOLTIPS["当期純利益"] },
+  { field: "純利益率", label: "純利益率", kind: "percent", category: "performance", unit: "%", tooltip: FILTER_TOOLTIPS["純利益率"] },
+  { field: "負債", label: "負債", kind: "currency_million", category: "balance", unit: "百万円", tooltip: FILTER_TOOLTIPS["負債"] },
+  { field: "流動負債", label: "流動負債", kind: "currency_million", category: "balance", unit: "百万円", tooltip: FILTER_TOOLTIPS["流動負債"] },
+  { field: "流動資産", label: "流動資産", kind: "currency_million", category: "balance", unit: "百万円", tooltip: FILTER_TOOLTIPS["流動資産"] },
+  { field: "総負債", label: "総負債", kind: "currency_million", category: "balance", unit: "百万円", tooltip: FILTER_TOOLTIPS["総負債"] },
+  { field: "現金及び現金同等物", label: "現金及び現金同等物", kind: "currency_million", category: "cash", unit: "百万円", tooltip: FILTER_TOOLTIPS["現金及び現金同等物"] },
+  { field: "投資有価証券", label: "投資有価証券", kind: "currency_million", category: "balance", unit: "百万円", tooltip: FILTER_TOOLTIPS["投資有価証券"] },
+  {
+    field: "ネットキャッシュ",
+    label: "ネットキャッシュ",
+    kind: "currency_million",
+    category: "cash",
+    unit: "百万円",
+    aliases: ["ネットキャッシュ（流動資産-負債）"],
+    tooltip: FILTER_TOOLTIPS["ネットキャッシュ"],
+  },
+  {
+    field: "ネットキャッシュ（流動資産-負債）",
+    label: "ネットキャッシュ",
+    kind: "currency_million",
+    category: "cash",
+    unit: "百万円",
+    aliases: ["ネットキャッシュ"],
+    tooltip: FILTER_TOOLTIPS["ネットキャッシュ"],
+  },
+  { field: "ネットキャッシュ比率", label: "ネットキャッシュ比率", kind: "percent", category: "cash", unit: "%", tooltip: FILTER_TOOLTIPS["ネットキャッシュ比率"] },
+];
+
+const registryByField = new Map<string, ScreenerFieldMeta>();
+for (const meta of BUILTIN_FIELDS) {
+  registryByField.set(meta.field, meta);
+}
+
+export function getFieldMeta(field: string): ScreenerFieldMeta | undefined {
+  return registryByField.get(field);
+}
+
+export function resolveStockFieldValue(
+  stock: Record<string, string | number | null | undefined>,
+  field: string
+): number | string | null | undefined {
+  const meta = getFieldMeta(field);
+  const keys = [field, ...(meta?.aliases ?? [])];
+  for (const key of keys) {
+    const v = stock[key];
+    if (v !== undefined && v !== null && v !== "") return v;
+  }
+  return stock[field];
+}
+
+export function uiValueToStored(kind: ScreenerFieldKind, uiValue: number): number {
+  switch (kind) {
+    case "percent":
+      return uiValue / 100;
+    case "currency_million":
+      return uiValue * 1_000_000;
+    default:
+      return uiValue;
+  }
+}
+
+export function storedValueToUi(kind: ScreenerFieldKind, stored: number): number {
+  switch (kind) {
+    case "percent":
+      return stored * 100;
+    case "currency_million":
+      return stored / 1_000_000;
+    default:
+      return stored;
+  }
+}
+
+const EXCLUDED_COLUMNS = new Set([
+  "会社名",
+  "銘柄コード",
+  "コード",
+  "業種",
+  "優先市場",
+  "市場タイプ",
+  "決算月",
+  "都道府県",
+  "_source_file",
+  "_row_index",
+]);
+
+function inferKindFromSample(sample: unknown): ScreenerFieldKind {
+  if (typeof sample !== "number") return "string";
+  if (sample >= 0 && sample <= 1 && !Number.isInteger(sample)) return "percent";
+  return "number";
+}
+
+export function buildScreenableFields(
+  columns: string[],
+  sampleRow?: Record<string, unknown>
+): ScreenerFieldMeta[] {
+  const seen = new Set<string>();
+  const result: ScreenerFieldMeta[] = [];
+
+  for (const col of columns) {
+    if (EXCLUDED_COLUMNS.has(col) || col.startsWith("_")) continue;
+    const builtin = registryByField.get(col);
+    if (builtin) {
+      if (!seen.has(builtin.field)) {
+        seen.add(builtin.field);
+        result.push(builtin);
+      }
+      continue;
+    }
+    const sample = sampleRow?.[col];
+    const kind =
+      typeof sample === "number"
+        ? inferKindFromSample(sample)
+        : sample === undefined || sample === null
+          ? "number"
+          : "string";
+    if (kind === "string") continue;
+    if (!seen.has(col)) {
+      seen.add(col);
+      result.push({
+        field: col,
+        label: col,
+        kind,
+        category: "basic",
+        unit: kind === "percent" ? "%" : kind === "currency_million" ? "百万円" : undefined,
+      });
+    }
+  }
+
+  const categoryOrder: ScreenerFieldCategory[] = [
+    "valuation",
+    "performance",
+    "balance",
+    "cash",
+    "basic",
+  ];
+  result.sort((a, b) => {
+    const ai = categoryOrder.indexOf(a.category);
+    const bi = categoryOrder.indexOf(b.category);
+    if (ai !== bi) return ai - bi;
+    return a.label.localeCompare(b.label, "ja");
+  });
+
+  return result;
+}
+
+export const OPERATOR_LABELS: Record<ScreenerOperator, string> = {
+  gte: "以上",
+  lte: "以下",
+  between: "範囲",
+  eq: "等しい",
+};
+
+export function formatConditionSummary(
+  condition: import("../types/stock").ScreenerCondition,
+  meta?: ScreenerFieldMeta
+): string {
+  const label = meta?.label ?? condition.field;
+  const unit = meta?.unit ?? "";
+  const op = OPERATOR_LABELS[condition.operator];
+  if (condition.operator === "between" && Array.isArray(condition.value)) {
+    const [a, b] = condition.value;
+    return `${label} ${a}〜${b}${unit}`;
+  }
+  const v = condition.value as number;
+  return `${label} ${op} ${v}${unit}`;
+}

--- a/stock_search/src/utils/searchFiltersMigration.ts
+++ b/stock_search/src/utils/searchFiltersMigration.ts
@@ -1,0 +1,100 @@
+import type { SearchFilters, ScreenerCondition, ScreenerState } from "../types/stock";
+
+function newId(): string {
+  return crypto.randomUUID();
+}
+
+type RangeMapping = {
+  field: string;
+  minKey: keyof SearchFilters;
+  maxKey: keyof SearchFilters;
+};
+
+const RANGE_MAPPINGS: RangeMapping[] = [
+  { field: "時価総額", minKey: "marketCapMin", maxKey: "marketCapMax" },
+  { field: "PBR", minKey: "pbrMin", maxKey: "pbrMax" },
+  { field: "ROE", minKey: "roeMin", maxKey: "roeMax" },
+  { field: "売上高", minKey: "revenueMin", maxKey: "revenueMax" },
+  { field: "営業利益", minKey: "operatingProfitMin", maxKey: "operatingProfitMax" },
+  { field: "営業利益率", minKey: "operatingMarginMin", maxKey: "operatingMarginMax" },
+  { field: "当期純利益", minKey: "netProfitMin", maxKey: "netProfitMax" },
+  { field: "純利益率", minKey: "netMarginMin", maxKey: "netMarginMax" },
+  { field: "自己資本比率", minKey: "equityRatioMin", maxKey: "equityRatioMax" },
+  { field: "PER(会予)", minKey: "forwardPEMin", maxKey: "forwardPEMax" },
+  { field: "PER(過去12ヶ月)", minKey: "trailingPEMin", maxKey: "trailingPEMax" },
+  { field: "PER(前年度)", minKey: "previousYearPEMin", maxKey: "previousYearPEMax" },
+  { field: "配当方向性", minKey: "dividendDirectionMin", maxKey: "dividendDirectionMax" },
+  { field: "配当利回り", minKey: "dividendYieldMin", maxKey: "dividendYieldMax" },
+  { field: "EPS(過去12ヶ月)", minKey: "trailingEpsMin", maxKey: "trailingEpsMax" },
+  { field: "EPS(予想)", minKey: "forwardEpsMin", maxKey: "forwardEpsMax" },
+  { field: "EPS(前年度)", minKey: "previousYearEpsMin", maxKey: "previousYearEpsMax" },
+  { field: "負債", minKey: "totalLiabilitiesMin", maxKey: "totalLiabilitiesMax" },
+  { field: "流動負債", minKey: "currentLiabilitiesMin", maxKey: "currentLiabilitiesMax" },
+  { field: "流動資産", minKey: "currentAssetsMin", maxKey: "currentAssetsMax" },
+  { field: "総負債", minKey: "totalDebtMin", maxKey: "totalDebtMax" },
+  { field: "現金及び現金同等物", minKey: "cashMin", maxKey: "cashMax" },
+  { field: "投資有価証券", minKey: "investmentsMin", maxKey: "investmentsMax" },
+  { field: "ネットキャッシュ", minKey: "netCashMin", maxKey: "netCashMax" },
+  { field: "ネットキャッシュ比率", minKey: "netCashRatioMin", maxKey: "netCashRatioMax" },
+];
+
+export function searchFiltersToConditions(filters: Partial<SearchFilters>): ScreenerCondition[] {
+  const conditions: ScreenerCondition[] = [];
+
+  for (const { field, minKey, maxKey } of RANGE_MAPPINGS) {
+    const minVal = filters[minKey];
+    const maxVal = filters[maxKey];
+    if (minVal !== null && minVal !== undefined && maxVal !== null && maxVal !== undefined) {
+      conditions.push({
+        id: newId(),
+        field,
+        operator: "between",
+        value: [minVal as number, maxVal as number],
+      });
+      continue;
+    }
+    if (minVal !== null && minVal !== undefined) {
+      conditions.push({
+        id: newId(),
+        field,
+        operator: "gte",
+        value: minVal as number,
+      });
+    }
+    if (maxVal !== null && maxVal !== undefined) {
+      conditions.push({
+        id: newId(),
+        field,
+        operator: "lte",
+        value: maxVal as number,
+      });
+    }
+  }
+
+  return conditions;
+}
+
+export const initialScreenerState = (): ScreenerState => ({
+  conditions: [],
+  companyName: "",
+  stockCode: "",
+  industries: [],
+  market: [],
+  prefecture: [],
+  marketType: ["JP", "US"],
+  excludeMissing: false,
+  sort: null,
+});
+
+export function searchFiltersToScreenerState(filters: Partial<SearchFilters>): ScreenerState {
+  return {
+    ...initialScreenerState(),
+    companyName: filters.companyName ?? "",
+    stockCode: filters.stockCode ?? "",
+    industries: filters.industries ?? [],
+    market: filters.market ?? [],
+    prefecture: filters.prefecture ?? [],
+    marketType: filters.marketType ?? ["JP", "US"],
+    conditions: searchFiltersToConditions(filters),
+  };
+}

--- a/stock_search/src/utils/urlParams.ts
+++ b/stock_search/src/utils/urlParams.ts
@@ -1,198 +1,146 @@
-import type { SearchFilters } from "../types/stock";
+import type { ScreenerCondition, ScreenerState, SortConfig } from "../types/stock";
+import { urlParamsToFilters } from "./urlParamsLegacy";
+import { searchFiltersToScreenerState } from "./searchFiltersMigration";
 
-// フィルターをURLパラメータに変換
-export const filtersToUrlParams = (filters: SearchFilters): URLSearchParams => {
+function encodeCondition(c: ScreenerCondition): string {
+  if (c.operator === "between" && Array.isArray(c.value)) {
+    return `${encodeURIComponent(c.field)}:between:${c.value[0]}~${c.value[1]}`;
+  }
+  return `${encodeURIComponent(c.field)}:${c.operator}:${c.value}`;
+}
+
+function decodeCondition(token: string): ScreenerCondition | null {
+  const parts = token.split(":");
+  if (parts.length < 3) return null;
+  const field = decodeURIComponent(parts[0]);
+  const operator = parts[1] as ScreenerCondition["operator"];
+  const raw = parts.slice(2).join(":");
+  if (!["gte", "lte", "between", "eq"].includes(operator)) return null;
+
+  if (operator === "between") {
+    const [a, b] = raw.split("~");
+    const min = parseFloat(a);
+    const max = parseFloat(b);
+    if (Number.isNaN(min) || Number.isNaN(max)) return null;
+    return { id: crypto.randomUUID(), field, operator, value: [min, max] };
+  }
+  const num = parseFloat(raw);
+  if (Number.isNaN(num)) return null;
+  return { id: crypto.randomUUID(), field, operator, value: num };
+}
+
+export const screenerToUrlParams = (screener: ScreenerState): URLSearchParams => {
   const params = new URLSearchParams();
 
-  // 文字列フィルター
-  if (filters.companyName) params.set("company", filters.companyName);
+  if (screener.companyName) params.set("company", screener.companyName);
+  if (screener.stockCode) params.set("code", screener.stockCode);
+  if (screener.market.length > 0) params.set("market", screener.market.join(","));
+  if (screener.prefecture.length > 0) params.set("prefecture", screener.prefecture.join(","));
+  if (screener.industries.length > 0) params.set("industries", screener.industries.join(","));
+  if (screener.marketType.length > 0) params.set("marketType", screener.marketType.join(","));
+  if (screener.excludeMissing) params.set("excludeMissing", "1");
 
-  // 複数選択フィルター
-  if (filters.market.length > 0) {
-    params.set("market", filters.market.join(","));
-  }
-  if (filters.prefecture.length > 0) {
-    params.set("prefecture", filters.prefecture.join(","));
-  }
-  if (filters.industries.length > 0) {
-    params.set("industries", filters.industries.join(","));
-  }
-  if (filters.marketType && filters.marketType.length > 0) {
-    params.set("marketType", filters.marketType.join(","));
+  if (screener.conditions.length > 0) {
+    params.set("sc", screener.conditions.map(encodeCondition).join(","));
   }
 
-  // 数値フィルター
-  const numericFilters: Array<{ key: keyof SearchFilters; param: string }> = [
-    { key: "marketCapMin", param: "mcMin" },
-    { key: "marketCapMax", param: "mcMax" },
-    { key: "pbrMin", param: "pbrMin" },
-    { key: "pbrMax", param: "pbrMax" },
-    { key: "roeMin", param: "roeMin" },
-    { key: "roeMax", param: "roeMax" },
-    { key: "revenueMin", param: "revMin" },
-    { key: "revenueMax", param: "revMax" },
-    { key: "operatingProfitMin", param: "opMin" },
-    { key: "operatingProfitMax", param: "opMax" },
-    { key: "operatingMarginMin", param: "omMin" },
-    { key: "operatingMarginMax", param: "omMax" },
-    { key: "netProfitMin", param: "npMin" },
-    { key: "netProfitMax", param: "npMax" },
-    { key: "netMarginMin", param: "nmMin" },
-    { key: "netMarginMax", param: "nmMax" },
-    { key: "equityRatioMin", param: "eqMin" },
-    { key: "equityRatioMax", param: "eqMax" },
-    { key: "forwardPEMin", param: "peMin" },
-    { key: "forwardPEMax", param: "peMax" },
-    { key: "trailingPEMin", param: "tpeMin" }, // PER(過去12ヶ月)(過去12ヶ月分)
-    { key: "trailingPEMax", param: "tpeMax" },
-    { key: "previousYearPEMin", param: "pypeMin" }, // PER(前年度)
-    { key: "previousYearPEMax", param: "pypeMax" },
-    { key: "dividendDirectionMin", param: "ddMin" },
-    { key: "dividendDirectionMax", param: "ddMax" },
-    { key: "dividendYieldMin", param: "dyMin" },
-    { key: "dividendYieldMax", param: "dyMax" },
-    { key: "trailingEpsMin", param: "tepsMin" },
-    { key: "trailingEpsMax", param: "tepsMax" },
-    { key: "forwardEpsMin", param: "fepsMin" },
-    { key: "forwardEpsMax", param: "fepsMax" },
-    { key: "previousYearEpsMin", param: "pyepsMin" }, // EPS(前年度)
-    { key: "previousYearEpsMax", param: "pyepsMax" },
-    { key: "totalLiabilitiesMin", param: "tlMin" },
-    { key: "totalLiabilitiesMax", param: "tlMax" },
-    { key: "currentLiabilitiesMin", param: "clMin" },
-    { key: "currentLiabilitiesMax", param: "clMax" },
-    { key: "currentAssetsMin", param: "caMin" },
-    { key: "currentAssetsMax", param: "caMax" },
-    { key: "totalDebtMin", param: "tdMin" },
-    { key: "totalDebtMax", param: "tdMax" },
-    { key: "cashMin", param: "cashMin" },
-    { key: "cashMax", param: "cashMax" },
-    { key: "investmentsMin", param: "invMin" },
-    { key: "investmentsMax", param: "invMax" },
-    { key: "netCashMin", param: "ncMin" },
-    { key: "netCashMax", param: "ncMax" },
-    { key: "netCashRatioMin", param: "ncrMin" },
-    { key: "netCashRatioMax", param: "ncrMax" },
-  ];
-
-  numericFilters.forEach(({ key, param }) => {
-    const value = filters[key];
-    if (value !== null && value !== undefined) {
-      params.set(param, value.toString());
-    }
-  });
+  if (screener.sort) {
+    params.set("sort", String(screener.sort.key));
+    params.set("sortDir", screener.sort.direction);
+  }
 
   return params;
 };
 
-// URLパラメータをフィルターに変換
-export const urlParamsToFilters = (searchParams: URLSearchParams): Partial<SearchFilters> => {
-  const filters: Partial<SearchFilters> = {};
+export const urlParamsToScreener = (searchParams: URLSearchParams): Partial<ScreenerState> => {
+  const partial: Partial<ScreenerState> = {};
 
-  // 文字列フィルター
   const company = searchParams.get("company");
-  if (company) filters.companyName = company;
+  if (company) partial.companyName = company;
 
-  // 複数選択フィルター
+  const code = searchParams.get("code");
+  if (code) partial.stockCode = code;
+
   const market = searchParams.get("market");
-  if (market) {
-    filters.market = market.split(",").filter(Boolean);
-  }
+  if (market) partial.market = market.split(",").filter(Boolean);
 
   const prefecture = searchParams.get("prefecture");
-  if (prefecture) {
-    filters.prefecture = prefecture.split(",").filter(Boolean);
-  }
+  if (prefecture) partial.prefecture = prefecture.split(",").filter(Boolean);
 
   const industries = searchParams.get("industries");
-  if (industries) {
-    filters.industries = industries.split(",").filter(Boolean);
-  }
+  if (industries) partial.industries = industries.split(",").filter(Boolean);
 
   const marketType = searchParams.get("marketType");
   if (marketType) {
-    const marketTypes = marketType.split(",").filter(Boolean) as ("JP" | "US")[];
-    if (marketTypes.length > 0) {
-      filters.marketType = marketTypes;
-    }
+    partial.marketType = marketType.split(",").filter(Boolean) as ("JP" | "US")[];
   }
 
-  // 数値フィルター
-  const numericMappings: Array<{ param: string; key: keyof SearchFilters }> = [
-    { param: "mcMin", key: "marketCapMin" },
-    { param: "mcMax", key: "marketCapMax" },
-    { param: "pbrMin", key: "pbrMin" },
-    { param: "pbrMax", key: "pbrMax" },
-    { param: "roeMin", key: "roeMin" },
-    { param: "roeMax", key: "roeMax" },
-    { param: "revMin", key: "revenueMin" },
-    { param: "revMax", key: "revenueMax" },
-    { param: "opMin", key: "operatingProfitMin" },
-    { param: "opMax", key: "operatingProfitMax" },
-    { param: "omMin", key: "operatingMarginMin" },
-    { param: "omMax", key: "operatingMarginMax" },
-    { param: "npMin", key: "netProfitMin" },
-    { param: "npMax", key: "netProfitMax" },
-    { param: "nmMin", key: "netMarginMin" },
-    { param: "nmMax", key: "netMarginMax" },
-    { param: "eqMin", key: "equityRatioMin" },
-    { param: "eqMax", key: "equityRatioMax" },
-    { param: "peMin", key: "forwardPEMin" },
-    { param: "peMax", key: "forwardPEMax" },
-    { param: "tpeMin", key: "trailingPEMin" }, // PER(過去12ヶ月)(過去12ヶ月分)
-    { param: "tpeMax", key: "trailingPEMax" },
-    { param: "pypeMin", key: "previousYearPEMin" }, // PER(前年度)
-    { param: "pypeMax", key: "previousYearPEMax" },
-    { param: "ddMin", key: "dividendDirectionMin" },
-    { param: "ddMax", key: "dividendDirectionMax" },
-    { param: "dyMin", key: "dividendYieldMin" },
-    { param: "dyMax", key: "dividendYieldMax" },
-    { param: "tepsMin", key: "trailingEpsMin" },
-    { param: "tepsMax", key: "trailingEpsMax" },
-    { param: "fepsMin", key: "forwardEpsMin" },
-    { param: "fepsMax", key: "forwardEpsMax" },
-    { param: "pyepsMin", key: "previousYearEpsMin" }, // EPS(前年度)
-    { param: "pyepsMax", key: "previousYearEpsMax" },
-    { param: "tlMin", key: "totalLiabilitiesMin" },
-    { param: "tlMax", key: "totalLiabilitiesMax" },
-    { param: "clMin", key: "currentLiabilitiesMin" },
-    { param: "clMax", key: "currentLiabilitiesMax" },
-    { param: "caMin", key: "currentAssetsMin" },
-    { param: "caMax", key: "currentAssetsMax" },
-    { param: "tdMin", key: "totalDebtMin" },
-    { param: "tdMax", key: "totalDebtMax" },
-    { param: "cashMin", key: "cashMin" },
-    { param: "cashMax", key: "cashMax" },
-    { param: "invMin", key: "investmentsMin" },
-    { param: "invMax", key: "investmentsMax" },
-    { param: "ncMin", key: "netCashMin" },
-    { param: "ncMax", key: "netCashMax" },
-    { param: "ncrMin", key: "netCashRatioMin" },
-    { param: "ncrMax", key: "netCashRatioMax" },
-  ];
+  if (searchParams.get("excludeMissing") === "1") {
+    partial.excludeMissing = true;
+  }
 
-  numericMappings.forEach(({ param, key }) => {
-    const value = searchParams.get(param);
-    if (value) {
-      const numValue = parseFloat(value);
-      if (!isNaN(numValue)) {
-        (filters as Record<string, string | number>)[key] = numValue;
-      }
+  const sc = searchParams.get("sc");
+  if (sc) {
+    const conditions: ScreenerCondition[] = [];
+    for (const token of sc.split(",")) {
+      const decoded = decodeCondition(token.trim());
+      if (decoded) conditions.push(decoded);
     }
-  });
+    if (conditions.length > 0) partial.conditions = conditions;
+  }
 
-  return filters;
+  const sortKey = searchParams.get("sort");
+  const sortDir = searchParams.get("sortDir");
+  if (sortKey && (sortDir === "asc" || sortDir === "desc")) {
+    partial.sort = { key: sortKey, direction: sortDir } as SortConfig;
+  }
+
+  return partial;
 };
 
-// 現在のフィルターでURLを更新
-export const updateUrlWithFilters = (filters: SearchFilters) => {
-  const params = filtersToUrlParams(filters);
-  const newUrl = `${window.location.pathname}?${params.toString()}`;
+/** 新形式 + 旧 SearchFilters 形式の読み取り互換 */
+export function mergeUrlIntoScreener(
+  current: ScreenerState,
+  searchParams: URLSearchParams
+): ScreenerState {
+  const fromNew = urlParamsToScreener(searchParams);
+  const hasNew =
+    searchParams.has("sc") ||
+    searchParams.has("code") ||
+    searchParams.has("excludeMissing") ||
+    searchParams.has("sort");
+
+  if (hasNew || Object.keys(fromNew).length > 0) {
+    return {
+      ...current,
+      ...fromNew,
+      conditions: fromNew.conditions ?? current.conditions,
+      sort: fromNew.sort !== undefined ? fromNew.sort : current.sort,
+    };
+  }
+
+  const legacy = urlParamsToFilters(searchParams);
+  if (Object.keys(legacy).length === 0) return current;
+
+  const migrated = searchFiltersToScreenerState(legacy);
+  return {
+    ...current,
+    ...migrated,
+    conditions: migrated.conditions.length > 0 ? migrated.conditions : current.conditions,
+  };
+}
+
+export const updateUrlWithScreener = (screener: ScreenerState) => {
+  const params = screenerToUrlParams(screener);
+  const qs = params.toString();
+  const newUrl = qs ? `${window.location.pathname}?${qs}` : window.location.pathname;
   window.history.replaceState({}, "", newUrl);
 };
 
-// 共有用URLを生成
-export const generateShareUrl = (filters: SearchFilters): string => {
-  const params = filtersToUrlParams(filters);
-  return `${window.location.origin}${window.location.pathname}?${params.toString()}`;
+export const generateShareUrl = (screener: ScreenerState): string => {
+  const params = screenerToUrlParams(screener);
+  const qs = params.toString();
+  return qs
+    ? `${window.location.origin}${window.location.pathname}?${qs}`
+    : `${window.location.origin}${window.location.pathname}`;
 };

--- a/stock_search/src/utils/urlParamsLegacy.ts
+++ b/stock_search/src/utils/urlParamsLegacy.ts
@@ -1,0 +1,198 @@
+import type { SearchFilters } from "../types/stock";
+
+// フィルターをURLパラメータに変換
+export const filtersToUrlParams = (filters: SearchFilters): URLSearchParams => {
+  const params = new URLSearchParams();
+
+  // 文字列フィルター
+  if (filters.companyName) params.set("company", filters.companyName);
+
+  // 複数選択フィルター
+  if (filters.market.length > 0) {
+    params.set("market", filters.market.join(","));
+  }
+  if (filters.prefecture.length > 0) {
+    params.set("prefecture", filters.prefecture.join(","));
+  }
+  if (filters.industries.length > 0) {
+    params.set("industries", filters.industries.join(","));
+  }
+  if (filters.marketType && filters.marketType.length > 0) {
+    params.set("marketType", filters.marketType.join(","));
+  }
+
+  // 数値フィルター
+  const numericFilters: Array<{ key: keyof SearchFilters; param: string }> = [
+    { key: "marketCapMin", param: "mcMin" },
+    { key: "marketCapMax", param: "mcMax" },
+    { key: "pbrMin", param: "pbrMin" },
+    { key: "pbrMax", param: "pbrMax" },
+    { key: "roeMin", param: "roeMin" },
+    { key: "roeMax", param: "roeMax" },
+    { key: "revenueMin", param: "revMin" },
+    { key: "revenueMax", param: "revMax" },
+    { key: "operatingProfitMin", param: "opMin" },
+    { key: "operatingProfitMax", param: "opMax" },
+    { key: "operatingMarginMin", param: "omMin" },
+    { key: "operatingMarginMax", param: "omMax" },
+    { key: "netProfitMin", param: "npMin" },
+    { key: "netProfitMax", param: "npMax" },
+    { key: "netMarginMin", param: "nmMin" },
+    { key: "netMarginMax", param: "nmMax" },
+    { key: "equityRatioMin", param: "eqMin" },
+    { key: "equityRatioMax", param: "eqMax" },
+    { key: "forwardPEMin", param: "peMin" },
+    { key: "forwardPEMax", param: "peMax" },
+    { key: "trailingPEMin", param: "tpeMin" }, // PER(過去12ヶ月)(過去12ヶ月分)
+    { key: "trailingPEMax", param: "tpeMax" },
+    { key: "previousYearPEMin", param: "pypeMin" }, // PER(前年度)
+    { key: "previousYearPEMax", param: "pypeMax" },
+    { key: "dividendDirectionMin", param: "ddMin" },
+    { key: "dividendDirectionMax", param: "ddMax" },
+    { key: "dividendYieldMin", param: "dyMin" },
+    { key: "dividendYieldMax", param: "dyMax" },
+    { key: "trailingEpsMin", param: "tepsMin" },
+    { key: "trailingEpsMax", param: "tepsMax" },
+    { key: "forwardEpsMin", param: "fepsMin" },
+    { key: "forwardEpsMax", param: "fepsMax" },
+    { key: "previousYearEpsMin", param: "pyepsMin" }, // EPS(前年度)
+    { key: "previousYearEpsMax", param: "pyepsMax" },
+    { key: "totalLiabilitiesMin", param: "tlMin" },
+    { key: "totalLiabilitiesMax", param: "tlMax" },
+    { key: "currentLiabilitiesMin", param: "clMin" },
+    { key: "currentLiabilitiesMax", param: "clMax" },
+    { key: "currentAssetsMin", param: "caMin" },
+    { key: "currentAssetsMax", param: "caMax" },
+    { key: "totalDebtMin", param: "tdMin" },
+    { key: "totalDebtMax", param: "tdMax" },
+    { key: "cashMin", param: "cashMin" },
+    { key: "cashMax", param: "cashMax" },
+    { key: "investmentsMin", param: "invMin" },
+    { key: "investmentsMax", param: "invMax" },
+    { key: "netCashMin", param: "ncMin" },
+    { key: "netCashMax", param: "ncMax" },
+    { key: "netCashRatioMin", param: "ncrMin" },
+    { key: "netCashRatioMax", param: "ncrMax" },
+  ];
+
+  numericFilters.forEach(({ key, param }) => {
+    const value = filters[key];
+    if (value !== null && value !== undefined) {
+      params.set(param, value.toString());
+    }
+  });
+
+  return params;
+};
+
+// URLパラメータをフィルターに変換
+export const urlParamsToFilters = (searchParams: URLSearchParams): Partial<SearchFilters> => {
+  const filters: Partial<SearchFilters> = {};
+
+  // 文字列フィルター
+  const company = searchParams.get("company");
+  if (company) filters.companyName = company;
+
+  // 複数選択フィルター
+  const market = searchParams.get("market");
+  if (market) {
+    filters.market = market.split(",").filter(Boolean);
+  }
+
+  const prefecture = searchParams.get("prefecture");
+  if (prefecture) {
+    filters.prefecture = prefecture.split(",").filter(Boolean);
+  }
+
+  const industries = searchParams.get("industries");
+  if (industries) {
+    filters.industries = industries.split(",").filter(Boolean);
+  }
+
+  const marketType = searchParams.get("marketType");
+  if (marketType) {
+    const marketTypes = marketType.split(",").filter(Boolean) as ("JP" | "US")[];
+    if (marketTypes.length > 0) {
+      filters.marketType = marketTypes;
+    }
+  }
+
+  // 数値フィルター
+  const numericMappings: Array<{ param: string; key: keyof SearchFilters }> = [
+    { param: "mcMin", key: "marketCapMin" },
+    { param: "mcMax", key: "marketCapMax" },
+    { param: "pbrMin", key: "pbrMin" },
+    { param: "pbrMax", key: "pbrMax" },
+    { param: "roeMin", key: "roeMin" },
+    { param: "roeMax", key: "roeMax" },
+    { param: "revMin", key: "revenueMin" },
+    { param: "revMax", key: "revenueMax" },
+    { param: "opMin", key: "operatingProfitMin" },
+    { param: "opMax", key: "operatingProfitMax" },
+    { param: "omMin", key: "operatingMarginMin" },
+    { param: "omMax", key: "operatingMarginMax" },
+    { param: "npMin", key: "netProfitMin" },
+    { param: "npMax", key: "netProfitMax" },
+    { param: "nmMin", key: "netMarginMin" },
+    { param: "nmMax", key: "netMarginMax" },
+    { param: "eqMin", key: "equityRatioMin" },
+    { param: "eqMax", key: "equityRatioMax" },
+    { param: "peMin", key: "forwardPEMin" },
+    { param: "peMax", key: "forwardPEMax" },
+    { param: "tpeMin", key: "trailingPEMin" }, // PER(過去12ヶ月)(過去12ヶ月分)
+    { param: "tpeMax", key: "trailingPEMax" },
+    { param: "pypeMin", key: "previousYearPEMin" }, // PER(前年度)
+    { param: "pypeMax", key: "previousYearPEMax" },
+    { param: "ddMin", key: "dividendDirectionMin" },
+    { param: "ddMax", key: "dividendDirectionMax" },
+    { param: "dyMin", key: "dividendYieldMin" },
+    { param: "dyMax", key: "dividendYieldMax" },
+    { param: "tepsMin", key: "trailingEpsMin" },
+    { param: "tepsMax", key: "trailingEpsMax" },
+    { param: "fepsMin", key: "forwardEpsMin" },
+    { param: "fepsMax", key: "forwardEpsMax" },
+    { param: "pyepsMin", key: "previousYearEpsMin" }, // EPS(前年度)
+    { param: "pyepsMax", key: "previousYearEpsMax" },
+    { param: "tlMin", key: "totalLiabilitiesMin" },
+    { param: "tlMax", key: "totalLiabilitiesMax" },
+    { param: "clMin", key: "currentLiabilitiesMin" },
+    { param: "clMax", key: "currentLiabilitiesMax" },
+    { param: "caMin", key: "currentAssetsMin" },
+    { param: "caMax", key: "currentAssetsMax" },
+    { param: "tdMin", key: "totalDebtMin" },
+    { param: "tdMax", key: "totalDebtMax" },
+    { param: "cashMin", key: "cashMin" },
+    { param: "cashMax", key: "cashMax" },
+    { param: "invMin", key: "investmentsMin" },
+    { param: "invMax", key: "investmentsMax" },
+    { param: "ncMin", key: "netCashMin" },
+    { param: "ncMax", key: "netCashMax" },
+    { param: "ncrMin", key: "netCashRatioMin" },
+    { param: "ncrMax", key: "netCashRatioMax" },
+  ];
+
+  numericMappings.forEach(({ param, key }) => {
+    const value = searchParams.get(param);
+    if (value) {
+      const numValue = parseFloat(value);
+      if (!isNaN(numValue)) {
+        (filters as Record<string, string | number>)[key] = numValue;
+      }
+    }
+  });
+
+  return filters;
+};
+
+// 現在のフィルターでURLを更新
+export const updateUrlWithFilters = (filters: SearchFilters) => {
+  const params = filtersToUrlParams(filters);
+  const newUrl = `${window.location.pathname}?${params.toString()}`;
+  window.history.replaceState({}, "", newUrl);
+};
+
+// 共有用URLを生成
+export const generateShareUrl = (filters: SearchFilters): string => {
+  const params = filtersToUrlParams(filters);
+  return `${window.location.origin}${window.location.pathname}?${params.toString()}`;
+};

--- a/stock_search/vitest.config.ts
+++ b/stock_search/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

CSV 読み込み後、EDINET DB スクリーナーを参考に **「＋ 条件を追加」** で指標・演算子・値を自由に積み上げて絞り込める動的スクリーニングを追加しました。

## 主な変更

- **ScreenerState / ScreenerCondition** — 動的条件モデル（AND 結合）
- **screenerEngine** — 単位変換（%、百万円）、列 alias、値なし除外オプション
- **ScreenerBar** — 件数表示、条件行、ソートドロップダウン、URL 共有
- **Sidebar** — 固定 NumRange を削除（業種・市場・都道府県・プリセットは維持）
- **URL** — 新形式 `?sc=ROE:gte:15,PBR:lte:1`、旧 `roeMin` 等は読取互換
- **プリセット / マイプリセット** — `conditions[]` 形式へ移行（v1 自動変換）
- **テスト** — `vitest` + `screenerEngine.test.ts`（7 件）

## 使い方

1. CSV を読み込む
2. テーブル上の **スクリーニング** 欄で「＋ 条件を追加」
3. 例: ROE **以上** 15、PBR **以下** 1.5
4. 「値なしを除外」で欠損行を除外可能
5. **URL共有** で条件付きリンクをコピー

## 制約

yfinance 由来 CSV の列のみが対象です（ROA/FCF/事業タグ等はデータパイプライン未対応）。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-22ac204e-084c-4faa-9f77-e71d147460f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22ac204e-084c-4faa-9f77-e71d147460f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

